### PR TITLE
Rework scales again, add geom_bar

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,6 +54,8 @@ Geoms:
 - =geom_line=
 - =geom_histogram=
 - =geom_freqpoly=
+- =geom_bar= (layout still broken, see
+  https://github.com/Vindaar/ggplotnim/issues/10 for more infos)
 
 Facets:
 - =facet_wrap=

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -440,8 +440,20 @@ func geom_point*(aes: Aesthetics = aes(),
                                   size: size)),
                 aes: aes)
 
-func geom_bar(): Geom =
-  result = Geom(kind: gkBar)
+func geom_bar*(aes: Aesthetics = aes(),
+               color: Color = grey20, # color of the bars
+               position = "stack",
+              ): Geom =
+  let pkKind = parseEnum[PositionKind](position)
+  let style = Style(lineType: ltSolid,
+                    lineWidth: 1.0, # draw 1 pt wide black line to avoid white pixels
+                                    # between bins at size of exactly 1.0 bin width
+                    color: color, # default color
+                    fillColor: color)
+  result = Geom(kind: gkBar,
+                aes: aes,
+                style: some(style),
+                position: pkKind)
 
 func geom_line*(aes: Aesthetics = aes(),
                 data = DataFrame(),

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -422,7 +422,7 @@ proc scale_x_log10*(): Scale =
   result = Scale(col: "", # will be filled when added to GgPlot obj
                  scKind: scTransformedData,
                  axKind: akX,
-                 kind: dcContinuous,
+                 dcKind: dcContinuous,
                  trans: proc(v: Value): Value =
                           result = %~ log10(v.toFloat))
 
@@ -431,7 +431,7 @@ proc scale_y_log10*(): Scale =
   result = Scale(col: "", # will be filled when added to GgPlot obj
                  scKind: scTransformedData,
                  axKind: akY,
-                 kind: dcContinuous,
+                 dcKind: dcContinuous,
                  trans: proc(v: Value): Value =
                           result = %~ log10(v.toFloat))
 
@@ -443,7 +443,7 @@ proc createLegend(view: var Viewport,
   ## creates a full legend within the given viewport based on the categories
   ## in `cat` with a headline `title` showing data points of `markers`
   let startIdx = view.len
-  case cat.kind
+  case cat.dcKind
   of dcDiscrete:
     view.layout(1, rows = cat.valueMap.len + 1)
   of dcContinuous:
@@ -752,7 +752,7 @@ iterator markerStylePairs(p: GgPlot, geom: Geom): (int, (MarkerKind, Style)) =
     lStyle = style
     for s in scales:
       # walk all scales and build the correct style
-      case s.kind
+      case s.dcKind
       of dcDiscrete:
         if s.col notin df:
           # constant value

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -1328,8 +1328,8 @@ proc handleLabels(view: var Viewport, p: GgPlot) =
   # essentially check whether
   # TODO: clean this up!
   var
-    xlabel: GraphObject
-    ylabel: GraphObject
+    xLabObj: GraphObject
+    yLabObj: GraphObject
     xlabTxt = ""
     ylabTxt = ""
     xMargin: Coord1D
@@ -1370,10 +1370,10 @@ proc handleLabels(view: var Viewport, p: GgPlot) =
     ylabTxt = "count"
     #ylabel = view.ylabel("count", margin = yMargin)
   else: discard
-  createLabel(yLabel, ylabel, yLabTxt, p.theme.yLabelMargin, yMargin)
-  createLabel(xLabel, xlabel, xLabTxt, p.theme.xLabelMargin, xMargin)
+  createLabel(yLabObj, ylabel, yLabTxt, p.theme.yLabelMargin, yMargin)
+  createLabel(xLabObj, xlabel, xLabTxt, p.theme.xLabelMargin, xMargin)
 
-  view.addObj @[xlabel, ylabel]
+  view.addObj @[xLabObj, yLabObj]
 
 proc generatePlot(view: Viewport, p: GgPlot, addLabels = true): Viewport =
   # first write all plots into dummy viewport

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -137,7 +137,7 @@ proc isDiscreteData(s: seq[Value], drawSamples: static bool = true): bool =
     else:
       let indices = toSeq(0 .. s.high)
     let elements = indices.mapIt(s[it]).toHashSet
-    if elements.card > (indices.len.float / 5.0).round.int:
+    if elements.card > (indices.len.float / 8.0).round.int:
       result = false
     else:
       result = true

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -215,19 +215,19 @@ proc getXYcols(p: GgPlot, geom: Geom): tuple[x, y: string] =
   else: y = p.aes.y.get
   result = (x: x.col, y: y.col)
 
+proc getAes(p:GgPlot, geom: Geom, axKind: AxisKind): Aesthetics =
+  case axKind
+  of akX:
+    if geom.aes.x.isSome: result = geom.aes
+    else: result = p.aes
+  of akY:
+    if geom.aes.y.isSome: result = geom.aes
+    else: result = p.aes
+
 proc getXYAes(p: GgPlot, geom: Geom): tuple[x, y: Aesthetics] =
   ## given both a `Geom` and a `GgPlot` object we need to choose the correct
   ## x, y aesthetics from the two.
-  var
-    x: Aesthetics
-    y: Aesthetics
-  # prefer geom x, y over plot x, y
-  if geom.aes.x.isSome: x = geom.aes
-  else: x = p.aes
-  if geom.aes.y.isSome: y = geom.aes
-  else: y = p.aes
-  result = (x: x, y: y)
-
+  result = (x: getAes(p, geom, akX), y: getAes(p, geom, akY))
 
 proc readXYcols(p: GgPlot, geom: Geom, outType: typedesc): tuple[x, y: seq[outType]] =
   ## given both a `Geom` and a `GgPlot` object we need to choose the correct

--- a/src/ggplotnim/formula.nim
+++ b/src/ggplotnim/formula.nim
@@ -84,6 +84,15 @@ type
   DataFrame* = object
     len*: int
     data*: OrderedTable[string, PersistentVector[Value]]
+    # TODO: we could possibly add the following two fields to a dataframe
+    # They're easy to determine when first creating a dataframe from either
+    # a file or seqs. Scales help us when calling `setInitialScale` for instane,
+    # so that we don't have to walk all of the data again in order to determine
+    # min and max. Same goes for the value kind. The only downside is when working
+    # with dataframes using dplyr-like procs we have to be careful to keep these
+    # up to data!
+    # `colScales: OrderedTable[string, ginger.Scale]`
+    # `colVkinds: OrderedTable[string, ValueKind]`
     case kind: DataFrameKind
     of dfGrouped:
       # a grouped data frame stores the keys of the groups and maps them to

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -69,7 +69,7 @@ type
       # not defined) and will never be called
       trans*: proc(v: Value): Value
     else: discard
-    case kind*: DiscreteKind
+    case dcKind*: DiscreteKind
     of dcDiscrete:
       # For discrete data this is a good solution. How about continuous data?
       valueMap*: OrderedTable[Value, ScaleValue]
@@ -130,7 +130,7 @@ type
     theme*: Theme
 
 proc `==`*(s1, s2: Scale): bool =
-  if s1.kind == s2.kind and
+  if s1.dcKind == s2.dcKind and
      s1.col == s2.col:
     # the other fields ``will`` be computed to the same!
     result = true
@@ -168,7 +168,7 @@ proc hash*(x: ScaleValue): Hash =
 proc hash*(x: Scale): Hash =
   result = hash(x.scKind.int)
   result = result !& hash(x.col)
-  case x.kind:
+  case x.dcKind:
   of dcDiscrete:
     for k, v in x.valueMap:
       result = result !& hash(k)

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -30,13 +30,13 @@ type
 
   ScaleValue* = object
     case kind*: ScaleKind
-    of scLinearData:
+    of scLinearData, scTransformedData:
       # just stores a data value
       val*: Value
     # TODO: overhaul this
-    of scTransformedData:
+    #of scTransformedData:
       # data under some transformation. E.g. log, tanh, ...
-      rawVal*: Value
+      #rawVal*: Value
     of scFillColor, scColor:
       # stores a color
       color*: Color
@@ -150,10 +150,10 @@ proc hash*(s: Style): Hash =
 proc hash*(x: ScaleValue): Hash =
   result = hash(x.kind.int)
   case x.kind:
-  of scLinearData:
+  of scLinearData, scTransformedData:
     result = result !& hash(x.val)
-  of scTransformedData:
-    result = result !& hash(x.rawVal)
+  #of scTransformedData:
+    #result = result !& hash(x.rawVal)
     # TODO: Hash proc?
   of scColor:
     result = result !& hash($x.color)

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -79,6 +79,11 @@ type
     of dcContinuous:
       # For continuous we might want to add a `Scale` in the ginger sense
       dataScale*: ginger.Scale
+      # and the closure to read the correct data, which takes care of mapping
+      # the data to the correct `ScaleKind`. For linear data it's just the data
+      # itself. For `transformedData` it applies the transformation. For color etc.
+      # the
+      mapData*: proc(): seq[ScaleValue]
 
   Facet* = object
     columns*: seq[string]

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -59,6 +59,7 @@ type
   Scale* = object
     # the column which this scale corresponds to
     col*: string
+    vKind*: ValueKind # the value kind of the data of `col`
     case scKind*: ScaleKind
     of scLinearData, scTransformedData:
       # which axis does it belong to?

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -158,6 +158,10 @@ suite "Geom":
     discard
 
 suite "GgPlot":
+  test "histogram with string based scale":
+    let mpg = toDf(readCsv("data/mpg.csv"))
+    ggplot(mpg, aes("class")) + geom_histogram() + ggsave("histotest.pdf")
+
   test "x,y aesthetics of geom picked over GgPlot":
     ## tests that the x, y aesthetics are picked from the present `geom`
     ## if x, y are defined, instead of the `GgPlot` object.

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -158,9 +158,14 @@ suite "Geom":
     discard
 
 suite "GgPlot":
-  test "histogram with string based scale":
+  test "histogram with discrete scale fails":
     let mpg = toDf(readCsv("data/mpg.csv"))
-    ggplot(mpg, aes("class")) + geom_histogram() + ggsave("histotest.pdf")
+    expect(ValueError):
+      ggplot(mpg, aes("class")) + geom_histogram() + ggsave("fails.pdf")
+
+  test "Bar plot with string based scale":
+    let mpg = toDf(readCsv("data/mpg.csv"))
+    ggplot(mpg, aes("class")) + geom_bar() + ggsave("bartest.pdf")
 
   test "x,y aesthetics of geom picked over GgPlot":
     ## tests that the x, y aesthetics are picked from the present `geom`


### PR DESCRIPTION
Adds the implementation for `geom_bar` and reworks how scales work (again).

Now all scales (including `x` and `y`) are actually `Scale` objects. In this case `scLinearData` or `scTransformedData`. This has some downsides from a performance point of view, if this is used completely (namely via reading the data possibly too often at the moment, because the code isn't completely aware of this yet) and due to wrapping the data in `ScaleValue` objects if the `mapData` proc is used to read the `Scale`'s data. 

Both should be easy fixes in a moment of clarity and with some time. But I wanted to finish this PR before going on vacation. The examples from the `bookPlots` dir all still seem to work, except `geom_bar` is working, except layouting issues, see https://github.com/Vindaar/ggplotnim/issues/10 for more infos.