### PR TITLE
Add travis CI, secondary axes and more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+sudo: required
+
+os:
+  - linux
+
+language: c
+dist: xenial
+
+matrix:
+  include:
+    # Build and test against the master (stable) and devel branches of Nim
+    # Build and test using both gcc and clang
+    - os: linux
+      env: CHANNEL=stable
+      compiler: gcc
+
+    - os: linux
+      env: CHANNEL=devel
+      compiler: gcc
+
+cache:
+  directories:
+    - "$HOME/.nimble"
+    - "$HOME/.choosenim"
+
+addons:
+  apt:
+     packages:
+       - libcairo2
+       - libcairo2-dev
+
+install:
+  - curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
+  - sh init.sh -y
+  - export PATH=$HOME/.nimble/bin:$PATH
+  - nimble refresh -y
+  - git clone https://github.com/Vindaar/chroma
+  - pushd chroma
+  - git fetch origin
+  - git checkout -t origin/addMoreSpaces
+  - nimble develop -y
+  - popd
+  - choosenim $CHANNEL
+
+script:
+  - nimble install -y
+  - nimble -y test

--- a/ggplotnim.nimble
+++ b/ggplotnim.nimble
@@ -17,6 +17,6 @@ requires "persvector#head"
 #requires "https://github.com/Vindaar/chroma#addMoreSpaces"
 
 task test, "Run tests":
-  exec "nim c -r tests/testDF.nim"
+  exec "nim c -r tests/testDf.nim"
   exec "nim c -r tests/tests.nim"
   exec "nim c -r tests/test_issue2.nim"

--- a/ggplotnim.nimble
+++ b/ggplotnim.nimble
@@ -11,7 +11,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 0.19.9"
-requires "https://github.com/Vindaar/seqmath"
+requires "https://github.com/Vindaar/seqmath#head"
 requires "https://github.com/Vindaar/ginger#head"
 requires "persvector#head"
 #requires "https://github.com/Vindaar/chroma#addMoreSpaces"

--- a/ggplotnim.nimble
+++ b/ggplotnim.nimble
@@ -19,3 +19,4 @@ requires "persvector#head"
 task test, "Run tests":
   exec "nim c -r tests/testDF.nim"
   exec "nim c -r tests/tests.nim"
+  exec "nim c -r tests/test_issue2.nim"

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -961,7 +961,7 @@ proc createLineGobj(view: var Viewport,
   for markerStyle, pointIdxs in pairs(msMap):
     var points = newSeq[Point](pointIdxs.len)
     for i, idx in pointIdxs:
-      points[i] = (x: xData[i], y: yData[i])
+      points[i] = (x: xData[idx], y: yData[idx])
     points.sort((x, y: Point) => cmp(x.x, y.x))
     result.add view.initPolyLine(points, some(markerStyle[1]))
 

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -1776,24 +1776,6 @@ proc customPosition(t: Theme): bool =
   let (xAes, yAes) = getXYAes(p, p.geoms[0])
   let xScale = setInitialScale(p, xAes.x)
   let yScale = setInitialScale(p, yAes.y)
-  # TODO: Check if `xdata.isDiscreteData` and handle discrete cases (possibly
-  # also `string` data, after reading `xdata` not into `float`, but into `Value`.
-  # TODO2: For latter we must make sure that reading `xdata` as `Value` actually
-  # gives us `VFloat` values, instead of `VString` with floats as string
-  # For a `DataFrame` this should work, but for a `Table` it won't (as it's
-  # `seq[string]` internally).
-  #let
-  #  minX = xdata.min
-  #  maxX = xdata.max
-  #xScale = (low: minX, high: maxX)
-  #var
-  #  minY: float
-  #  maxY: float
-  #if yAes.y.isSome: #p.aes.y.isSome:
-  #  let ydata = p.data.dataTo(p.aes.y.get.col, float)
-  #  minY = ydata.min
-  #  maxY = ydata.max
-  #  yScale = (low: minY, high: maxY)
 
   # create the plot
   var img = initViewport(xScale = some(xScale),

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -759,10 +759,12 @@ proc applyScale(aes: Aesthetics, scale: Scale): Aesthetics =
     case scale.axKind
     of akX:
       if aes.x.isSome:
+        mscale.dataScale = aes.x.get.dataScale
         mscale.col = aes.x.get.col
         result.x = some(mscale)
     of akY:
       if aes.y.isSome:
+        mscale.dataScale = aes.y.get.dataScale
         mscale.col = aes.y.get.col
         result.y = some(mscale)
   of scFillColor, scColor: result.color = some(mscale)

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -596,6 +596,7 @@ proc genDiscreteLegend(view: var Viewport,
            c1(quant(0.3, ukCentimeter).toRelative(some(ch.wImg)).val),
         y: c1(0.5)),
       labelText,
+      textKind = goText,
       alignKind = taLeft,
       name = "markerText"
     )
@@ -632,6 +633,7 @@ proc createLegend(view: var Viewport,
       Coord(x: header.origin.x,
             y: c1(0.5)),
       cat.col,
+      textKind = goText,
       alignKind = taLeft,
       name = "legendHeader")
     # set to bold
@@ -1605,6 +1607,7 @@ proc generateFacetPlots(view: Viewport, p: GgPlot): Viewport =
     let text = pair.mapIt($it[0] & ": " & $it[1]).join(", ")
     let headerText = headerView.initText(c(0.5, 0.5),
                                          text,
+                                         textKind = goText,
                                          alignKind = taCenter,
                                          name = "facetHeaderText")
     headerView.addObj headerText
@@ -1742,7 +1745,8 @@ proc ggcreate*(p: GgPlot): Viewport =
                     color: black)
     let title = titleView.initText(c(0.0, 0.5),
                                    p.title,
-                                   taLeft,
+                                   textKind = goText,
+                                   alignKind = taLeft,
                                    font = some(font))
     titleView.addObj title
     img[1] = titleView

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -668,7 +668,7 @@ proc createLegend(view: var Viewport,
     view.genContinuousLegend(cat, markers)
 
   # get the first viewport for the header
-  if startIdx > 0:
+  if startIdx < view.len:
     var header = view[startIdx]
     var label = header.initText(
       Coord(x: header.origin.x,

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -257,6 +257,9 @@ proc fillScale(scaleOpt: Option[Scale], df: DataFrame,
     data = @[Value(kind: VString, str: scale.col)]
     isDiscrete = true
     vKind = VString
+  if vKind == VNull:
+    echo "WARNING: Unexpected data type VNull of column: ", scale.col, "!"
+    return none[Scale]()
   var res: Scale
   if isDiscrete:
     # generate a discrete `Scale`

--- a/src/ggplotnim/formula.nim
+++ b/src/ggplotnim/formula.nim
@@ -1419,6 +1419,14 @@ template bind_rows*(dfs: varargs[DataFrame], id: string = ""): DataFrame =
   let args = zip(ids, dfs)
   bind_rows(args, id)
 
+proc head*(df: DataFrame, num: int): DataFrame =
+  ## returns the head of the DataFrame. `num` elements
+  result = df[0 ..< num]
+
+proc tail*(df: DataFrame, num: int): DataFrame =
+  ## returns the tail of the DataFrame. `num` elements
+  result = df[^num .. df.high]
+
 ################################################################################
 ####### FORMULA
 ################################################################################

--- a/src/ggplotnim/formula.nim
+++ b/src/ggplotnim/formula.nim
@@ -456,6 +456,8 @@ template makeMath(op: untyped): untyped =
     if v.kind in {VFloat, VInt} and
        w.kind in {VFloat, VInt}:
       result = Value(kind: VFloat, fnum: `op`(v.toFloat, w.toFloat))
+    elif v.kind == VNull or w.kind == VNull:
+      result = Value(kind: VNull)
     else:
       raise newException(Exception, "Math operation does not make sense for " &
         "Value kind " & $v.kind & "!")

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -51,6 +51,11 @@ type
   #  btTrue, # for Scales, which belong to an axis, e.g. continuous x, y
   #  btFalse # for Scales that do not directly belong to an axis, e.g. color Scale
 
+  SecondaryAxis* = object
+    trans*: Option[FormulaNode] # possible transformation of the first axis to arrive at second
+    name*: string
+    axKind*: AxisKind
+
   # TODO: should not one scale belong to only one axis?
   # But if we do that, how do we find the correct scale in the seq[Scale]?
   # Replace seq[Scale] by e.g. Table[string, Scale] where string is some
@@ -59,6 +64,7 @@ type
   Scale* = object
     # the column which this scale corresponds to
     col*: string
+    name*: string
     vKind*: ValueKind # the value kind of the data of `col`
     case scKind*: ScaleKind
     of scLinearData, scTransformedData:
@@ -69,6 +75,7 @@ type
       # For scLinearData the transformation proc is just the identity (or
       # not defined) and will never be called
       trans*: proc(v: Value): Value
+      secondaryAxis*: Option[SecondaryAxis] # a possible secondary x, y axis
     else: discard
     case dcKind*: DiscreteKind
     of dcDiscrete:

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -127,7 +127,7 @@ type
     xlabelMargin*: Option[float]
     ylabel*: Option[string]
     ylabelMargin*: Option[float]
-
+    legendPosition*: Option[Coord]
 
   GgPlot*[T] = object
     data*: T

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -99,6 +99,8 @@ type
   # Uses the default ``cairo`` backend
   Draw* = object
     fname*: string
+    width*: Option[float]
+    height*: Option[float]
 
   # helper object to compose `ggvega` via `+` with `ggplot`
   # Used to show a plot using the Vega-Lite backend

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -147,3 +147,9 @@ suite "Data frame tests":
 
     echo cylDrvFiltered
     #echo mpg.filter(f{"class" == "suv"})
+
+  test "Unequal":
+    let mpg = toDf(readCsv("data/mpg.csv"))
+
+    let mpgNoSuv = mpg.filter(f{"class" != "suv"})
+    check (%~ "suv") notin mpgNoSuv["class"].unique

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -302,7 +302,7 @@ suite "GgPlot":
     let yLab = plt.children[4].objects.filterIt(it.name == "yLabel")
     template checkLabel(lab, labName, text, posTup, rot): untyped =
       check lab.name == labName
-      check lab.kind == goText
+      check lab.kind == goLabel
       check lab.txtText == text
       check lab.txtAlign == taCenter
       check lab.txtPos.x.toRelative.pos.almostEqual(posTup.x.toRelative.pos)
@@ -339,7 +339,7 @@ suite "GgPlot":
     let yLab = view.objects.filterIt(it.name == "yLabel")
     template checkLabel(lab, labName, text, rot): untyped =
       check lab.name == labName
-      check lab.kind == goText
+      check lab.kind == goLabel
       check lab.txtText == text
       check lab.txtAlign == taCenter
       check lab.rotate == rot

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -107,6 +107,14 @@ suite "Value":
     check $n19 == "\"2.007E+00\""
     check $n20 == "\"9.329E-01\""
 
+  test "Math with Values":
+    check (v1 * v2).kind == VFloat
+    check (v1 + v1).kind == VFloat
+    check (v1 + v1) == %~ 2
+    check (v1 * v1).kind == VFloat
+    check almostEqual((v1 * v2).toFloat, 1.5)
+    check almostEqual((v1 / v2).toFloat, 2.0 / 3.0)
+    check v1 * v6 == Value(kind: VNull)
 
 suite "Formula":
   test "Testing ~ formula creation":


### PR DESCRIPTION
This PR is a big step towards making sure the package doesn't break after every commit. It's both made sure that installation works (although isn't trivial yet, due to `chroma` colors PR not being merged yet) and the tests are actually run.

In addition the following things were added:
- With the additions to `ginger` the secondary axes were implemented.

- Scales have a `name` field to set labels for a `Scale` (instead of
  going explicitly via `Theme`; *TODO* unify this!)

- Also work was done to better support `data` fields for individual
geoms. For instance the `Scale` would not be filled based on the the
data of the geom, but rather of the GgPlot!

- In addition now we can set the legend position directly on the whole
plot via `legend_position`.

- The ability to choose the output file size was added to `ggsave`.

- Support for unequal was added for `Value` and `FormulaNode`.

- `head` and `tail` for data frames was added.

- DataFrames can be accessed via slices with backwards indices
