### PR TITLE
Improve tick formatting of log and fix y margin placement

### DIFF
--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -1611,8 +1611,10 @@ proc handleLabels(view: var Viewport, p: GgPlot) =
         marginVar = Coord1D(pos: 1.1, kind: ukStrHeight,
                             text: labNames[labLens], font: font)
       of akY:
-        marginVar = Coord1D(pos: 1.1, kind: ukStrWidth,
-                            text: labNames[labLens], font: font)
+        marginVar = Coord1D(pos: 1.0, kind: ukStrWidth,
+                            text: labNames[labLens], font: font) +
+                    Coord1D(pos: 0.3, kind: ukCentimeter)
+
   template createLabel(label, labproc, labTxt, themeField, marginVal: untyped,
                        isSecond = false): untyped =
     if themeField.isSome:

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -1435,7 +1435,7 @@ proc tickposlog(minv, maxv: float): (seq[string], seq[float]) =
   for i in 0 ..< numTicks div 10:
     let base = (minv * pow(10, i.float))
     let test = linspace(base, 9 * base, 9)
-    labs.add $base
+    labs.add formatTickValue(base)
     labs.add toSeq(0 ..< 8).mapIt("")
     labPos.add test.mapIt(it.log10)
   labs.add $maxv

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -324,7 +324,7 @@ suite "GgPlot":
                      y: Coord1D(pos: 423.0944881889764, kind: ukPoint, length: some((val: 480.0, unit: ukPoint)))),
                none[float]())
     checkLabel(yLab[0], "yLabel", "exp",
-               Coord(x: Coord1D(pos: -45.02637795275591, kind: ukPoint, length: some((val: 640.0, unit: ukPoint))),
+               Coord(x: Coord1D(pos: -0.07931594488188977, kind: ukRelative),
                      y: Coord1D(pos: 0.5, kind: ukRelative)),
                some(-90.0))
     check yLab[0].txtPos.x.toPoints.pos != quant(1.0, ukCentimeter).toPoints.val


### PR DESCRIPTION
The formatting for log scales is improved by using ginger's new formatter.

Also fixes the margin of y labels to be 0.3 cm relative to the longest label.