### PR TITLE
Fixes #20 by introducing fixed `isInt`

### DIFF
--- a/ggplotnim.nimble
+++ b/ggplotnim.nimble
@@ -17,6 +17,7 @@ task test, "Run tests":
   exec "nim c -r tests/testDf.nim"
   exec "nim c -r tests/tests.nim"
   exec "nim c -r tests/test_issue2.nim"
+  exec "nim c -r tests/test_issue20.nim"
 
 
 import ospaths, strutils, strformat

--- a/tests/test_issue20.nim
+++ b/tests/test_issue20.nim
@@ -1,0 +1,18 @@
+import ggplotnim
+import unittest
+
+test "Issue #20 - `isDigit` was removed":
+  let n1 = %~ "1.1"
+  let n2 = %~ "1.3e5"
+  let n3 = %~ "aba"
+  let n4 = %~ "1..1"
+  let n5 = %~ "123"
+  let n6 = %~ "100_000"
+  let n7 = %~ "_100_000_"
+  check not n1.isInt
+  check not n2.isInt
+  check not n3.isInt
+  check not n4.isInt
+  check n5.isInt
+  check n6.isInt
+  check n7.isInt # this is a little unintuitive, but a downside of our simple def.


### PR DESCRIPTION
Since `isDigit` for strings was recently removed on devel in https://github.com/nim-lang/Nim/pull/12535 replace the functionality by a new `isInt` func, which checks if all characters are in `{'0'..'9','_'}`. Note that this is not a perfect int check, but only an approximation used to guide the `toDf` conversion proc. 

Also note: the `isNumber` of this commit is still a little broken. See #18 for an improved version.