### PR TITLE
Remove explicit shell dependency, fixes #22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ install:
   - nimble refresh -y
   - choosenim $CHANNEL
   - nimble install ntangle -y
-  - nimble install shell -y # to make sure recipes don't break...
 
 script:
   - nimble install -y

--- a/ggplotnim.nimble
+++ b/ggplotnim.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Sebastian Schmidt"
 description   = "A port of ggplot2 for Nim"
 license       = "MIT"

--- a/ggplotnim.nimble
+++ b/ggplotnim.nimble
@@ -55,32 +55,9 @@ task docs, "Generate HTML docs using the Org file":
     let fname = f.basename & ".html"
     mvFile fname, "docs/" & $fname
 
-import shell
 task recipes, "Generate and run all recipes":
   exec "ntangle recipes.org"
-  # without using shell running all these commands sometimes makes
-  # travis throw up and stall....
-  shell:
-    nim c "-r recipes/rStackedMpgHistogram.nim"
-    nim c "-r recipes/rNewtonAcceleration.nim"
-    nim c "-r recipes/rMpgStackedPointPlot.nim"
-    nim c "-r recipes/rLinePlotSize.nim"
-    nim c "-r recipes/rMpgHistoBinWidth.nim"
-    nim c "-r recipes/rMpgContinuousColorPoints.nim"
-    nim c "-r recipes/rAxionMassVsDensity.nim"
-    nim c "-r recipes/rMpgHistoNumBins.nim"
-    nim c "-r recipes/rMpgHistoCustomBreaks.nim"
-    nim c "-r recipes/rMpgCustomColorPoint.nim"
-    nim c "-r recipes/rMpgHistoPlusPoints.nim"
-    nim c "-r recipes/rSimpleLinePlot.nim"
-    nim c "-r recipes/rMpgSimpleBarPlot.nim"
-    nim c "-r recipes/rTwoSensorsBadStyle.nim"
-    nim c "-r recipes/rTwoSensorsGoodStyle.nim"
-    nim c "-r recipes/rPrebinnedHisto.nim"
-    nim c "-r recipes/rMassAttenuationFunction.nim"
-    nim c "-r recipes/rAxionMassesLogLog.nim"
-    nim c "-r recipes/rStackedMpgFreqpoly.nim"
-    nim c "-r recipes/rMpgStackedBarPlot.nim"
+  exec "nim c -r recipes/runRecipes.nim"
 
 task recipesPlots, "Generate the PNGs from all recipes":
   exec """for f in media/recipes/r*.pdf; do inkscape $f --export-png="${f/.pdf/.png}"; done"""

--- a/recipes/runRecipes.nim
+++ b/recipes/runRecipes.nim
@@ -1,0 +1,23 @@
+import shell
+
+shell:
+  nim c "-r recipes/rStackedMpgHistogram.nim"
+  nim c "-r recipes/rNewtonAcceleration.nim"
+  nim c "-r recipes/rMpgStackedPointPlot.nim"
+  nim c "-r recipes/rLinePlotSize.nim"
+  nim c "-r recipes/rMpgHistoBinWidth.nim"
+  nim c "-r recipes/rMpgContinuousColorPoints.nim"
+  nim c "-r recipes/rAxionMassVsDensity.nim"
+  nim c "-r recipes/rMpgHistoNumBins.nim"
+  nim c "-r recipes/rMpgHistoCustomBreaks.nim"
+  nim c "-r recipes/rMpgCustomColorPoint.nim"
+  nim c "-r recipes/rMpgHistoPlusPoints.nim"
+  nim c "-r recipes/rSimpleLinePlot.nim"
+  nim c "-r recipes/rMpgSimpleBarPlot.nim"
+  nim c "-r recipes/rTwoSensorsBadStyle.nim"
+  nim c "-r recipes/rTwoSensorsGoodStyle.nim"
+  nim c "-r recipes/rPrebinnedHisto.nim"
+  nim c "-r recipes/rMassAttenuationFunction.nim"
+  nim c "-r recipes/rAxionMassesLogLog.nim"
+  nim c "-r recipes/rStackedMpgFreqpoly.nim"
+  nim c "-r recipes/rMpgStackedBarPlot.nim"

--- a/tests/tCompareRecipes.nim
+++ b/tests/tCompareRecipes.nim
@@ -9,8 +9,11 @@ NOTE: this test depends on imagemagick, since it converts the PNG files to PPM!
 
 suite "Compare recipe output":
   test "Compare recipe output":
+    # first run recipes to make sure we have current recipe plots in
+    # media/recipes which we can compare with media/expected
     let runRecipes = shellVerbose:
-      nimble recipes # currently done in .travis.yml
+      nimble recipes
+    check runRecipes[1] == 0
     let files = @["rStackedMpgHistogram.png",
                   "rNewtonAcceleration.png",
                   "rMpgStackedPointPlot.png",


### PR DESCRIPTION
I moved the usage of `shell` to an individual file `runRecipes`. This way it shouldn't be required before installation anymore.