### PR TITLE
add tests using `noCairo` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,4 @@ install:
 script:
   - nimble install -y
   - nimble -y fulltest
+  - nimble -y testCI

--- a/ggplotnim.nimble
+++ b/ggplotnim.nimble
@@ -10,9 +10,17 @@ srcDir        = "src"
 
 requires "nim >= 1.0.0"
 requires "https://github.com/Vindaar/seqmath >= 0.1.3"
-requires "ginger >= 0.1.6"
+requires "ginger >= 0.1.7"
 requires "persvector >= 1.0.0"
 requires "shell >= 0.2.2" # to run tCompareRecipes test
+
+task testCI, "Run standard tests w/o cairo dependency":
+  # This runs all tests suitable for a CI environment, which does not provide
+  # cairo. Most tests are independent of cairo anyways
+  exec "nim c -d:noCairo -r tests/testDf.nim"
+  exec "nim c -d:noCairo -r tests/tests.nim"
+  exec "nim c -d:noCairo -r tests/test_issue2.nim"
+  exec "nim c -d:noCairo -r tests/test_issue20.nim"
 
 task test, "Run standard tests":
   exec "nim c -r tests/testDf.nim"

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -440,8 +440,14 @@ suite "GgPlot":
       check lab.kind == goLabel
       check lab.txtText == text
       check lab.txtAlign == taCenter
-      check lab.txtPos.x.toRelative.pos.almostEqual(posTup.x.toRelative.pos)
       check lab.txtPos.y.toRelative.pos.almostEqual(posTup.y.toRelative.pos)
+      when not defined(noCairo):
+        ## This check only works if we compile with the cairo backend. That is because the
+        ## placement of the text in y position depends explicitly on the extent of the
+        ## text, which is determined using cairo's TTextExtents object. The dummy backend
+        ## provides only zeroes for these numbers.
+        check lab.txtPos.x.toRelative.pos.almostEqual(posTup.x.toRelative.pos)
+
       check lab.rotate == rot
       check lab.txtFont == Font(family: "sans-serif", size: 12.0, bold: false,
                                 slant: fsNormal, color: color(0.0, 0.0, 0.0, 1.0))


### PR DESCRIPTION
A single test has to be modified to avoid one check, since it
explicitly tests the `getTextExtents`, which cannot work without cairo.