### PR TITLE
add fn macro alternative for json interoperability

### DIFF
--- a/ggplotnim.nimble
+++ b/ggplotnim.nimble
@@ -21,18 +21,21 @@ task testCI, "Run standard tests w/o cairo dependency":
   exec "nim c -d:noCairo -r tests/tests.nim"
   exec "nim c -d:noCairo -r tests/test_issue2.nim"
   exec "nim c -d:noCairo -r tests/test_issue20.nim"
+  exec "nim c -d:noCairo -r tests/test_issue28.nim"
 
 task test, "Run standard tests":
   exec "nim c -r tests/testDf.nim"
   exec "nim c -r tests/tests.nim"
   exec "nim c -r tests/test_issue2.nim"
   exec "nim c -r tests/test_issue20.nim"
+  exec "nim c -r tests/test_issue28.nim"
 
 task fulltest, "Run all tests, including recipe comparison (requires ntangle)":
   exec "nim c -r tests/testDf.nim"
   exec "nim c -r tests/tests.nim"
   exec "nim c -r tests/test_issue2.nim"
   exec "nim c -r tests/test_issue20.nim"
+  exec "nim c -r tests/test_issue28.nim"
   exec "nim c -r tests/tCompareRecipes.nim"
 
 import ospaths, strutils, strformat

--- a/src/ggplotnim/formula.nim
+++ b/src/ggplotnim/formula.nim
@@ -1282,9 +1282,14 @@ proc buildFormula(n: NimNode): NimNode =
   else:
     raise newException(Exception, "Not implemented! " & $n.kind)
 
-macro `{}`*(x, y: untyped): untyped =
-  if x.repr == "f":
+macro `{}`*(x: untyped{ident}, y: untyped): untyped =
+  if x.strVal == "f":
     result = buildFormula(y)
+
+macro `fn`*(x: untyped): untyped =
+  let arg = if x.kind == nnkStmtList: x[0] else: x
+  expectKind arg, nnkCurly
+  result = buildFormula(arg[0])
 
 proc unique*(v: PersistentVector[Value]): seq[Value] =
   ## returns a seq of all unique values in `v`

--- a/tests/test_issue28.nim
+++ b/tests/test_issue28.nim
@@ -1,0 +1,19 @@
+import ggplotnim
+import json
+
+template accept(x) =
+  static: assert(compiles(x))
+
+template reject(x) =
+  static: assert(not compiles(x))
+
+accept:
+  let f = fn {"Channel" == "Ch 0"}
+accept:
+  let f2 = fn({"Channel" == "Ch 0"})
+accept:
+  let f3 = fn:
+    {"Channel" == "Ch 0"}
+
+reject:
+  let f = f{"Channel" == "Ch 0"}


### PR DESCRIPTION
The default `f{}` macro does not work if `json` is imported. See
issue #28 for reference.