### PR TITLE
Improve recipe checks

### DIFF
--- a/recipes/runRecipes.nim
+++ b/recipes/runRecipes.nim
@@ -1,6 +1,6 @@
 import shell
 
-shell:
+let res = shellVerbose:
   nim c "-r recipes/rStackedMpgHistogram.nim"
   nim c "-r recipes/rNewtonAcceleration.nim"
   nim c "-r recipes/rMpgStackedPointPlot.nim"
@@ -22,3 +22,5 @@ shell:
   nim c "-r recipes/rStackedMpgFreqpoly.nim"
   nim c "-r recipes/rMpgStackedBarPlot.nim"
   nim c "-r recipes/rBarPlotRotatedLabels.nim"
+if res[1] != 0:
+  raise newException(Exception, "Failed to build or run at least one recipe!")

--- a/tests/tCompareRecipes.nim
+++ b/tests/tCompareRecipes.nim
@@ -47,5 +47,11 @@ suite "Compare recipe output":
     let expected = convertRead("media/expected")
     let isnow = convertRead("media/recipes")
     check isnow.len == expected.len
+    template checkFiles(f1, f2, fname: untyped): untyped =
+      # store in `comp` to avoid check obliterating our terminal with the diff
+      let comp = f1 == f2
+      check comp
+      if not comp:
+        echo "Comparison failed for file: ", fname
     for i in 0 ..< files.len:
-      check expected[i] == isnow[i]
+      checkFiles(expected[i], isnow[i], files[i])

--- a/tests/tCompareRecipes.nim
+++ b/tests/tCompareRecipes.nim
@@ -13,7 +13,7 @@ suite "Compare recipe output":
     # media/recipes which we can compare with media/expected
     let runRecipes = shellVerbose:
       nimble recipes
-    check runRecipes[1] == 0
+    require runRecipes[1] == 0
     let files = @["rStackedMpgHistogram.png",
                   "rNewtonAcceleration.png",
                   "rMpgStackedPointPlot.png",


### PR DESCRIPTION
This PR first of all makes sure that the recipes are successfully built and run and fails otherwise. Secondly it improves the error given by `tCompareRecipes.nim` in case one or more files fail to compare.