### PR TITLE
Add `unique`, symmetric `setDiff`, `readCsv` taking stream, `row` accessor

### DIFF
--- a/recipes.org
+++ b/recipes.org
@@ -622,7 +622,8 @@ let muOverRho = logMuOverRho.mapIt(exp(it))
 
 const massAttenuationFile = "data/mass_attenuation_nist_data.txt"
 # skip one line after header, second header line
-var dfMuRhoTab = toDf(readCsv(massAttenuationFile, skipLines = 1, sep = ' '))
+var dfMuRhoTab = toDf(readCsv(massAttenuationFile, header = "#", 
+                              skipLines = 1, sep = ' '))
   # convert MeV energy to keV
   .mutate(f{"Energy" ~ "Energy" * 1000.0})
   .filter(f{"Energy" >= energies.min and "Energy" <= energies.max})

--- a/recipes/rMassAttenuationFunction.nim
+++ b/recipes/rMassAttenuationFunction.nim
@@ -12,7 +12,8 @@ let muOverRho = logMuOverRho.mapIt(exp(it))
 
 const massAttenuationFile = "data/mass_attenuation_nist_data.txt"
 # skip one line after header, second header line
-var dfMuRhoTab = toDf(readCsv(massAttenuationFile, skipLines = 1, sep = ' '))
+var dfMuRhoTab = toDf(readCsv(massAttenuationFile, header = "#", 
+                              skipLines = 1, sep = ' '))
   # convert MeV energy to keV
   .mutate(f{"Energy" ~ "Energy" * 1000.0})
   .filter(f{"Energy" >= energies.min and "Energy" <= energies.max})

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -2725,32 +2725,60 @@ proc countLines(s: var FileStream): int =
     inc result
   s.setPosition(0)
 
-proc readCsv*(fname: string,
+proc checkHeader(s: Stream, fname, header: string): bool =
+  ## checks whether the given file contains the header `header`
+  result = true
+  if header.len > 0:
+    var headerBuf: string
+    if s.peekLine(headerBuf):
+      result = headerBuf.startsWith(header)
+    else:
+      raise newException(IOError, "The input file " & $fname & " seems to be empty.")
+
+proc readCsv*(s: Stream,
               sep = ',',
-              header = "#",
-              skipLines = 0): OrderedTable[string, seq[string]] =
-  ## returns a CSV file as a table of `header` keys vs. `seq[string]`
+              header = "",
+              skipLines = 0,
+              colNames: seq[string] = @[],
+              fname = "<unknown>"): OrderedTable[string, seq[string]] =
+  ## returns a `Stream` with CSV like data as a table of `header` keys vs. `seq[string]`
   ## values, where idx 0 corresponds to the first data value
   ## The `header` field can be used to designate the symbol used to
   ## differentiate the `header`. By default `#`.
-  var s = newFileStream(fname, fmRead)
-  if s == nil:
-    quit("cannot open the file" & fname)
-
-  let lineCount = countLines(s)
+  ## If `colNames` has values, the real header of the CSV file will be skipped
+  ## (if it exists).
+  # first check if the file even has a header of type `header`
+  let hasHeader = checkHeader(s, fname, header)
 
   var parser: CsvParser
   open(parser, s, fname, separator = sep, skipInitialSpace = true)
-  var isHeader = true
-  parser.readHeaderRow()
+
+  if colNames.len > 0:
+    # if `colNames` available, use as header
+    parser.headers = colNames
+    if hasHeader:
+      # and skip the real header
+      discard parser.readRow()
+  elif hasHeader:
+    # read the header and use it
+    parser.readHeaderRow()
+  else:
+    # file has no header nor user gave column names, raise
+    raise newException(IOError, "Input neither has header starting with " &
+      $header & " nor were column names provided!")
+
   result = initOrderedTable[string, seq[string]]()
   # filter out the header, delimiter, if any
   parser.headers.keepItIf(it != header)
+
+  # possibly strip the headers and create the result table of columns
   var colHeaders: seq[string]
   for colUnstripped in items(parser.headers):
     let col = colUnstripped.strip
     colHeaders.add col
-    result[col] = newSeqOfCap[string](lineCount)
+    result[col] = newSeqOfCap[string](5000) # start with a reasonable default cap
+
+  # parse the actual file using the headers
   var lnCount = 0
   while readRow(parser):
     if lnCount < skipLines:
@@ -2761,6 +2789,23 @@ proc readCsv*(fname: string,
       parser.rowEntry(col).removeSuffix({' '})
       result[colHeaders[i]].add parser.rowEntry(col)
   parser.close()
+
+proc readCsv*(fname: string,
+              sep = ',',
+              header = "",
+              skipLines = 0,
+              colNames: seq[string] = @[]): OrderedTable[string, seq[string]] =
+  ## returns a CSV file as a table of `header` keys vs. `seq[string]`
+  ## values, where idx 0 corresponds to the first data value
+  ## The `header` field can be used to designate the symbol used to
+  ## differentiate the `header`. By default `#`.
+  ## If `colNames` has values, the real header of the CSV file will be skipped
+  ## (if it exists).
+  var s = newFileStream(fname, fmRead)
+  if s == nil:
+    quit("cannot open the file" & fname)
+  result = s.readCsv(sep, header, skipLines, colNames, fname = fname)
+  s.close()
 
 proc writeCsv*(df: DataFrame, filename: string, sep = ',', header = "",
                precision = 4) =

--- a/src/ggplotnim/formula.nim
+++ b/src/ggplotnim/formula.nim
@@ -1519,9 +1519,10 @@ proc innerJoin*(df1, df2: DataFrame, by: string): DataFrame =
   for k in keys(seqTab):
     result[k] = seqTab[k].toPersistentVector
 
-proc setDiff*(df1, df2: DataFrame): DataFrame =
+proc setDiff*(df1, df2: DataFrame, symmetric = false): DataFrame =
   ## returns a `DataFrame` with all elements in `df1` that are not found in
-  ## `df2`
+  ## `df2`. If `symmetric` is true, the symmetric difference of the dataset is
+  ## returned, i.e. elements which are either not in `df1` ``or`` not in `df2`.
   ## NOTE: Currently simple implementation based on `HashSet`. Iterates
   ## both dataframes once to generate sets, calcualtes intersection and returns
   ## difference as new `DataFrame`
@@ -1531,7 +1532,11 @@ proc setDiff*(df1, df2: DataFrame): DataFrame =
     for row in df:
       rowSet.incl row
     rowSet
-  let diff = dfToSet(df1) - dfToSet(df2)
+  var diff: HashSet[Value]
+  if symmetric:
+    diff = symmetricDifference(dfToSet(df1), dfToSet(df2))
+  else:
+    diff = dfToSet(df1) - dfToSet(df2)
   for row in diff:
     result.add row
   result.len = diff.card

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1,4 +1,4 @@
-import ggplotnim, unittest, sequtils, math, strutils, os
+import ggplotnim, unittest, sequtils, math, strutils, streams
 import algorithm
 
 suite "Data frame tests":
@@ -420,7 +420,7 @@ suite "Data frame tests":
     check expPrecision12 == dfPrecision12
 
   test "CSV parsing with spaces":
-    const csvData = """
+    let csvDataStream = newStringStream("""
 t_in_s,  C1_in_V,  C2_in_V,  type
 -3.0000E-06,  -2.441E-04,  -6.836E-04,  T1
 -2.9992E-06,  2.441E-04,  -6.836E-04 ,  T1
@@ -430,9 +430,8 @@ t_in_s,  C1_in_V,  C2_in_V,  type
 -2.9960E-06,  4.395E-04,  4.883E-04  ,  T2
 -2.9952E-06,  1.465E-04,  -2.930E-04 ,  T2
 -2.9944E-06,  -3.418E-04,  -1.270E-03,  T2
-"""
-    writeFile("testCsvSpaces.csv", csvData)
-    let csvRead = readCsv("testCsvSpaces.csv")
+""")
+    let csvRead = readCsv(csvDataStream)
     let texp = @[-3.0000E-06, -2.9992E-06, -2.9984E-06, -2.9976E-06, -2.9968E-06,
                  -2.9960E-06, -2.9952E-06, -2.9944E-06]
     let c1Exp = @[-2.441E-04, 2.441E-04, 1.025E-03, 1.025E-03, 9.277E-04, 4.395E-04,
@@ -448,7 +447,6 @@ t_in_s,  C1_in_V,  C2_in_V,  type
     check df["C1_in_V"].vToSeq == dfExp["C1_in_V"].vToSeq
     check df["C2_in_V"].vToSeq == dfExp["C2_in_V"].vToSeq
     check df["type"].vToSeq == dfExp["type"].vToSeq
-    removeFile("testCsvSpaces.csv")
 
   test "Summarize":
     let mpg = toDf(readCsv("data/mpg.csv"))

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -502,3 +502,35 @@ t_in_s,  C1_in_V,  C2_in_V,  type
     let x2 = toSeq(0 .. 10)
     let df = seqsToDf(x1, x2)
     check df.filter(f{isNull("x2") == false})["x2"].vToSeq == %~ x2
+
+  test "Unique - duplicates using all columns":
+    # given some data containing duplicates
+    let dataDuplStream = newStringStream("""
+t_in_s,  C1_in_V,  C2_in_V,  type
+-3.0000E-06,  -2.441E-04,  -6.836E-04,  T1
+-2.9992E-06,  2.441E-04,  -6.836E-04 ,  T1
+-2.9984E-06,  1.025E-03,  -8.789E-04 ,  T1
+-2.9976E-06,  1.025E-03,  -2.930E-04 ,  T1
+-2.9992E-06,  2.441E-04,  -6.836E-04 ,  T1
+-2.9984E-06,  1.025E-03,  -8.789E-04 ,  T1
+-2.9976E-06,  1.025E-03,  -2.930E-04 ,  T1
+-2.9968E-06,  9.277E-04,  2.930E-04  ,  T2
+""")
+    let df = toDf(readCsv(dataDuplStream))
+    check df.len == 8
+    let dfUnique = df.unique
+    check dfUnique.len == 5
+
+  test "Unique - duplicates using subset of columns":
+    let s1 = @[1, 2, 3, 4, 5]
+    let s2 = @["A", "E", "A", "D", "E"]
+    let s3 = @["B", "G", "B", "G", "X"]
+    let df = seqsToDF({ "id" : s1,
+                        "Start" : s2,
+                        "Stop" : s3 })
+    check df.len == 5
+    let dfUniqueAll = df.unique
+    check dfUniqueAll.len == 5
+    # now only use columns start and stop
+    let dfUnique = df.unique("Start", "Stop")
+    check dfUnique.len == 4

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -534,3 +534,31 @@ t_in_s,  C1_in_V,  C2_in_V,  type
     # now only use columns start and stop
     let dfUnique = df.unique("Start", "Stop")
     check dfUnique.len == 4
+
+  test "setDiff":
+    # remove duplicates of `mpg` (for some reason there are 9 duplicates..)
+    let mpg = toDf(readCsv("data/mpg.csv")).unique
+    let mpgS1 = mpg[0 .. 25]
+    let mpgS2 = mpg[20 .. 29]
+    block:
+      # S1 is primary
+      let exp = mpg[0 .. 19].arrange(toSeq(keys(mpg)))
+      let res = setDiff(mpgS1, mpgS2).arrange(toSeq(keys(mpg)))
+      check exp.len == res.len
+      for i in 0 ..< exp.len:
+        check exp[i] == res[i]
+    block:
+      # S2 is primary
+      let exp = mpg[26 .. 29].arrange(toSeq(keys(mpg)))
+      let res = setDiff(mpgS2, mpgS1).arrange(toSeq(keys(mpg)))
+      check exp.len == res.len
+      for i in 0 ..< exp.len:
+        check exp[i] == res[i]
+    block:
+      # symmetric difference
+      let exp = bind_rows(mpg[0 .. 19], mpg[26 .. 29], id = "")
+        .arrange(toSeq(keys(mpg)))
+      let res = setDiff(mpgS1, mpgS2, symmetric = true).arrange(toSeq(keys(mpg)))
+      check exp.len == res.len
+      for i in 0 ..< exp.len:
+        check exp[i] == res[i]


### PR DESCRIPTION
- Adds a `unique` proc working on a whole `DataFrame` instead of only on a single column. The name is `unique` instead of its counterpart `dplyr.distinct`, because the latter is a keyword in Nim.
- A version of `setDiff` is added, which can return the symmetric difference of two dataframes. 
- `readCsv` has an overload, which works on a stream directly instead of a specific file.
- there was a **breaking change** of the `header` argument of `readCsv`. For better handling of headers (or non existing ones) the default `header` value is now `""` instead of `"#"`. If the used header is actually `#`, the `readCsv` call must be changed. For files without a header at all though, a `colNames` argument was added, which allows to use those names instead.
- finally a `row` accessor for data frames was added to allow to get the row at index `idx` as a `Value VObject`. This isn't very efficient, but convenient (and currently in use in `unique` and `setDiff` :/). There is a for this via `[]` too.
