### PR TITLE
avoid emphasizing numbers in column names

### DIFF
--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -562,3 +562,33 @@ t_in_s,  C1_in_V,  C2_in_V,  type
       check exp.len == res.len
       for i in 0 ..< exp.len:
         check exp[i] == res[i]
+
+  test "Custom column names when reading CSV like data":
+    # given some data without a header and column names
+    let dataDuplStream = newStringStream("""
+-3.0000E-06,  -2.441E-04,  -6.836E-04,  T1
+-2.9992E-06,  2.441E-04,  -6.836E-04 ,  T1
+-2.9984E-06,  1.025E-03,  -8.789E-04 ,  T1
+""")
+    # define columns
+    let cols = @["V1", "V2", "V3", "Channel"]
+    let df = toDf(readCsv(dataDuplStream, colNames = cols))
+    check df.len == 3
+    check df.getKeys == cols
+
+  test "Column names containing numbers":
+    # given some data without a header and column names
+    let dataDuplStream = newStringStream("""
+-3.0000E-06,  -2.441E-04,  -6.836E-04,  T1
+-2.9992E-06,  2.441E-04,  -6.836E-04 ,  T1
+-2.9984E-06,  1.025E-03,  -8.789E-04 ,  T1
+""")
+    # define columns
+    let cols = @["0", "1", "2", "3"]
+    let colsNot = @["\"0\"", "\"1\"", "\"2\"", "\"3\""]
+    let df = toDf(readCsv(dataDuplStream, colNames = cols))
+    check df.len == 3
+    check df.getKeys == cols
+    # redundant but a showcase what happened previously
+    for k in zip(df.getKeys, colsNot):
+      check k[0] != k[1]

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -173,6 +173,18 @@ suite "Value":
     check $n21 == "\"2.441E-04\""
     check $n22 == "\"-2.441E-04\""
 
+    # check that `emphStrNumber` can be disabled
+    echo n16.pretty(emphStrNumber = false).repr
+    echo n16.str.repr
+    check n16.pretty(emphStrNumber = false) == "6.084E+01"
+    check n17.pretty(emphStrNumber = false) == "1.676E+01"
+    check n18.pretty(emphStrNumber = false) == "6.863E+00"
+    check n19.pretty(emphStrNumber = false) == "2.007E+00"
+    check n20.pretty(emphStrNumber = false) == "9.329E-01"
+    check n21.pretty(emphStrNumber = false) == "2.441E-04"
+    check n22.pretty(emphStrNumber = false) == "-2.441E-04"
+
+
   test "Math with Values":
     check (v1 * v2).kind == VFloat
     check (v1 + v1).kind == VFloat


### PR DESCRIPTION
Previously we could end up with a DF with column names, which are explicitly annotated as strings if the name was a valid number. 

This also now allows to echo `VFloat` values as without explicitly showing the quotation marks.  