### PR TITLE
`Scale` is now a `ref object` to avoid excessive stack usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ install:
   - nimble install ntangle -y
 
 script:
+  # limit our stack size to avoid regressing after PR #36 w/o noticing
+  - ulimit -s 1024
   - nimble install -y
   - nimble -y fulltest
   - nimble -y testCI

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -457,6 +457,7 @@ proc fillScaleImpl(
   ## NOTE: The given `col` arg is not necessarily exactly a DF key anymore, since
   ## it might contain two or more columns as its basis
   # get the data column we scale by
+  result = new Scale
   if isDiscrete:
     # convert to set to filter duplicates, back to seq and sort
     # TODO: we could also use `sequtils.deduplicate` here
@@ -1061,7 +1062,7 @@ proc `+`*(p: GgPlot, theme: Theme): GgPlot =
 proc applyScale(aes: Aesthetics, scale: Scale): Aesthetics =
   ## applies the given `scale` to the `aes` by returning a modified
   ## `aes`
-  var mscale = scale
+  var mscale = deepCopy(scale)
   result = aes
   case mscale.scKind
   of scLinearData, scTransformedData:
@@ -1340,6 +1341,7 @@ macro genGetScale(field: untyped): untyped =
   let name = ident("get" & $field.strVal & "Scale")
   result = quote do:
     proc `name`(filledScales: FilledScales, geom = Geom(gid: 0)): Scale =
+      result = new Scale
       if filledScales.`field`.main.isSome:
         # use main
         result = filledScales.`field`.main.get

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -69,7 +69,7 @@ type
   # e.g. `xaxis`, `<name of geom>.xaxis` etc.?
   ScaleTransform* = proc(v: Value): Value
 
-  Scale* = object
+  Scale* = ref object
     # the column which this scale corresponds to
     col*: string
     name*: string
@@ -288,6 +288,7 @@ proc hash*(x: Scale): Hash =
     result = result !& hash(x.dataScale)
   result = !$result
 
+proc `$`*(s: Scale): string
 proc `$`*(f: Facet): string =
   result = "(columns: "
   for i, x in f.columns:


### PR DESCRIPTION
Scale previously was a huge stack waster. This caused the failures
seen in:
https://github.com/nim-lang/Nim/pull/13206

The test =tests/tests.nim= previously required a stack of about 3600
kB to avoid a stack overflow. With the =Scale= being a =ref object= we
get that down to 135 kB!

I simply checked the impact of making each used object a `ref object` on the `tests.nim` test case. 

![impact_ref_object_on_stack_usage](https://user-images.githubusercontent.com/7742232/74550342-888b5780-4f51-11ea-8283-279ba2078258.png)