### PR TITLE
add canvasColor field to theme, allow setting via `canvasColor`

### DIFF
--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -167,6 +167,8 @@ type
     xLabelSecondary*: Option[string]
     yLabelSecondary*: Option[string]
     legendPosition*: Option[Coord]
+    canvasColor*: Option[Color] # background color of the whole canvas
+    plotBackgroundColor*: Option[Color] # background color of a plot
     discreteScaleMargin*: Option[Quantity] # margin applied to scale of discrete kindn default 0.2 `cm`
 
   GgPlot*[T] = object

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -511,3 +511,30 @@ suite "GgPlot":
                       height(view).toPoints(some(view.hView)).val + quant(xMargin, ukCentimeter).toPoints.val,
                       epsilon = 1e-6)
     plt.ggdraw("exp2.pdf")
+
+suite "Theme":
+  test "Canvas background color":
+    let mpg = toDf(readCsv("data/mpg.csv"))
+    let white = color(1.0, 1.0, 1.0)
+    proc checkPlt(plt: GgPlot) =
+      check plt.theme.canvasColor.isSome
+      check plt.theme.canvasColor.unsafeGet == white
+      let pltGinger = ggcreate(plt)
+      # don't expect root viewport to have more than 1 element here
+      check pltGinger.view.objects.len == 1
+      let canvas = pltGinger.view.objects[0]
+      check canvas.kind == goRect
+      check canvas.style.isSome
+      let canvasStyle = canvas.style.get
+      check canvasStyle.fillColor == white
+
+    block:
+      let plt = ggplot(mpg, aes("hwy", "cty")) +
+        geom_point() +
+        canvasColor(color = white)
+      checkPlt(plt)
+    block:
+      let plt = ggplot(mpg, aes("hwy", "cty")) +
+        geom_point() +
+        theme_opaque()
+      checkPlt(plt)


### PR DESCRIPTION
Also adds a theme with a white background, `theme_opaque`.

This is useful to get for instance a white canvas background. Especially when saving a plot as a PNG this can be handy.

In principle this PR also exposes the `plotBackgroundColor` field of the `theme`, which is applied to the background of the actual plot (currently `grey92` by default). However, this will only be properly added together with an option to set the color of the grid lines. Then we can add a `theme_bw`, which has a white plot background and grey or black grid lines. Will be done at a later time.