### PR TITLE
force minimum data scale to 0 for geom_bar, stat identity, fixes #61

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.3.1
+- fixes #61, by forcing the minimum y value to be 0 for =geom_bar= if
+  identity statistics is being used.
+
 * v0.3.0
 - =aes= now not only accespts strings, but also numbers, which will
   also be wrapped in a =FormulaNode= of kind =fkVariable=. No need to

--- a/src/ggplotnim/postprocess_scales.nim
+++ b/src/ggplotnim/postprocess_scales.nim
@@ -538,7 +538,7 @@ proc postProcessScales*(filledScales: var FilledScales, p: GgPlot) =
       of stIdentity:
         # essentially take same data as for point
         filledGeom = filledIdentityGeom(df, g, filledScales)
-        # still a geom, make sure bottom is still at 0!
+        # still a histogram like geom, make sure bottom is still at 0!
         filledGeom.yScale = (low: 0.0, high: filledGeom.yScale.high)
       of stBin:
         # calculate histogram
@@ -551,13 +551,14 @@ proc postProcessScales*(filledScales: var FilledScales, p: GgPlot) =
       of stIdentity:
         # essentially take same data as for point
         filledGeom = filledIdentityGeom(df, g, filledScales)
+        # still a geom_bar, make sure bottom is still at 0!
+        filledGeom.yScale = (low: 0.0, high: filledGeom.yScale.high)
       of stCount:
         # count values in classes
         filledGeom = filledCountGeom(df, g, filledScales)
       of stBin:
         raise newException(Exception, "For continuous binning of your data use " &
           "`geom_histogram` instead!")
-
     if not xScale.isEmpty:
       xScale = mergeScales(xScale, filledGeom.xScale)
       yScale = mergeScales(yScale, filledGeom.yScale)
@@ -565,6 +566,7 @@ proc postProcessScales*(filledScales: var FilledScales, p: GgPlot) =
       xScale = filledGeom.xScale
       yScale = filledGeom.yScale
     filledScales.geoms.add filledGeom
+
   let (finalXScale, _, _) = calcTickLocations(xScale, p.numXTicks)
   let (finalYScale, _, _) = calcTickLocations(yScale, p.numYTicks)
 

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -828,3 +828,21 @@ suite "Annotations":
             ylim(-1, 1) + # at the moment ymin, ymax are not considered for the plot range (that's a bug)
             ggtitle("Spike raster plot")
         )
+
+    test "geom_bar w/ stat identity has yscale at 0":
+      ## ref: issue #61
+      ## we forgot to force the minimum value for geom_bar used for identity stat
+      ## to 0. This meant the automatically determined data scale (even minimum y)
+      ## was used, resulting in a botched plot
+
+      let df = seqsToDf({ "Age" : @[22, 54, 34],
+                          "Height" : @[1.87, 1.75, 1.78],
+                          "Name" : @["Mike", "Laura", "Sue"] })
+      let plt = ggcreate(
+        ggplot(df, aes("Name","Height")) +
+          geom_bar(stat="identity")
+      )
+
+      let expScale = (0.0, 2.0)
+      check plt.view[4].yScale == expScale
+      check plt.filledScales.yScale == expScale


### PR DESCRIPTION
This was simply an oversight. We forgot to force the minimum value of the y scale to 0 in case `geom_bar` was used with `stat = "identity"`. This was handled correctly only for `geom_histogram` and `geom_freqpoly`.

This fixes issue #61.