### PR TITLE
Some column improvements

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,9 @@
+* v0.3.4
+- allow creation of colunms from other int and float types (other than
+  =int64= and =float64=) via =toColumn=
+- allow access of DF columns with mutability (~[]=~ returns ~var
+  Column~)
+
 * v0.3.3
 - allow negative values in =geom_bar= and =geom_histogram= if identity
   statistics is used

--- a/src/ggplotnim/dataframe/arraymancer_backend.nim
+++ b/src/ggplotnim/dataframe/arraymancer_backend.nim
@@ -148,7 +148,7 @@ proc contains*(df: DataFrame, key: string): bool =
   ## a column in the `DataFrame`
   result = df.data.hasKey(key)
 
-proc `[]`*(df: DataFrame, k: string): Column {.inline.} =
+proc `[]`*(df: DataFrame, k: string): var Column {.inline.} =
   result = df.data[k]
 
 proc `[]`*(df: DataFrame, k: Value): Column {.inline.} =

--- a/src/ggplotnim/dataframe/column.nim
+++ b/src/ggplotnim/dataframe/column.nim
@@ -19,14 +19,14 @@ template toColumn*(c: Column): Column = c
 
 func high*(c: Column): int = c.len - 1
 
-proc toColumn*[T: float | int | string | bool | Value](t: Tensor[T]): Column =
-  when T is int:
+proc toColumn*[T: SomeFloat | SomeInteger | string | bool | Value](t: Tensor[T]): Column =
+  when T is SomeInteger:
     result = Column(kind: colInt,
-                    iCol: t,
+                    iCol: t.asType(int),
                     len: t.size)
-  elif T is float:
+  elif T is SomeFloat:
     result = Column(kind: colFloat,
-                    fCol: t,
+                    fCol: t.asType(float),
                     len: t.size)
   elif T is bool:
     result = Column(kind: colBool,
@@ -69,9 +69,9 @@ proc newColumn*(kind = colNone, length = 0): Column =
 
 
 proc toColKind*[T](dtype: typedesc[T]): ColKind =
-  when T is float:
+  when T is SomeFloat:
     result = colFloat
-  elif T is int:
+  elif T is SomeInteger:
     result = colInt
   elif T is bool:
     result = colBool
@@ -433,13 +433,13 @@ proc add*(c1, c2: Column): Column =
     result = toColumn concat(c1.toObject.oCol, c2.toObject.oCol, axis = 0)
   result.len = c1.len + c2.len
 
-proc toColumn*[T: float | string | int | bool | Value](s: openArray[T]): Column =
+proc toColumn*[T: SomeFloat | SomeInteger | string | bool | Value](s: openArray[T]): Column =
   var vals = newTensor[T](s.len)
   for i, x in s:
     vals[i] = x
   result = toColumn(vals)
 
-proc toColumn*[T: float | string | int | bool | Value](x: T): Column =
+proc toColumn*[T: SomeFloat | SomeInteger | string | bool | Value](x: T): Column =
   # also possible to create single row column, but inefficient
   # for `summarize` though there's no way around
   let vals = newTensorWith[T](1, x)

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -26,6 +26,21 @@ suite "Data frame tests":
       check "three" in df
       check "four" in df
 
+  test "Creation of DF w/ int, float other than int64, float64":
+    let a = @[123'u8, 12, 55]
+    let b = @[1.123'f32, 4.234, 1e12]
+    let c = @[1001'i32, 1002, 1003]
+    var df = seqsToDf({ "a" : a,
+                        "b" : b })
+    check df["a"].kind == colInt
+    check df["b"].kind == colFloat
+    check df["a"].toTensor(int) == a.toTensor.asType(int)
+    check df["b"].toTensor(float) == b.toTensor.asType(float)
+    # check toColumn directly
+    df["c"] = toColumn c
+    check df["c"].kind == colInt
+    check df["c"].toTensor(int) == c.toTensor.asType(int)
+
   test "Extending a DF by a column":
     let a = [1, 2, 3]
     let b = [3, 4, 5]

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -41,6 +41,33 @@ suite "Data frame tests":
     check df["c"].kind == colInt
     check df["c"].toTensor(int) == c.toTensor.asType(int)
 
+  test "Accessed column of DF is mutable / reference semantics":
+    let a = @[123'u8, 12, 55]
+    let aRepl = @[123'u8, 12, 33]
+    let b = @[1.123'f32, 4.234, 1e12]
+    var df = seqsToDf({ "a" : a })
+    check df["a"].kind == colInt
+    check df["a"].toTensor(int) == a.toTensor.asType(int)
+    df["a"][df.high] = 33
+    check df["a"].kind == colInt
+    check df["a"].toTensor(int) == aRepl.toTensor.asType(int)
+    df["a"] = b
+    check df["a"].kind == colFloat
+    check df["a"].toTensor(float) == b.toTensor.asType(float)
+
+    # check reference semantics
+    let bMod = @[1.123'f32, 4.234, 1e4]
+    var colB = df["a"]
+    # modifying `colB` modifies `df["a"]`
+    colB[df.high] = 1e4
+    check df["a"].toTensor(float) == bMod.toTensor.asType(float)
+
+    # modifying underlying tensor modifies data too
+    let bMod2 = @[1.123'f32, 4.234, 1e6]
+    var tensorB = df["a"].toTensor(float)
+    tensorB[df.high] = 1e6
+    check df["a"].toTensor(float) == bMod2.toTensor.asType(float)
+
   test "Extending a DF by a column":
     let a = [1, 2, 3]
     let b = [3, 4, 5]


### PR DESCRIPTION
Some small column improvements. One can now hand other int / float types (int8, float32 etc.) as arguments to `toColumn` or straight `df["key"] = ...`. 

Note, for arraymancer releases prior to https://github.com/mratsim/Arraymancer/pull/437 will see slight performance regressions on assignments of `float` and `int` tensors, since `asType` will map the whole tensor regardless of the input / output types.

Also `[]=(df: DataFrame, key)` now returns a `var Column` instead of `Column`. This allows to directly change the retrieved column. Since both the data frame, the column and arraymancer tensor are reference objects anyways, this only makes sense. 

So `df["x"][idx] = val` is now valid.