### PR TITLE
fix DateTime recipe to get reproducible CI

### DIFF
--- a/recipes.org
+++ b/recipes.org
@@ -1278,12 +1278,15 @@ let y = x.mapIt(pow(sin(it), 2.0))
 
 let df = seqsToDf(x, y)
 
+# helper template to get a reproducible `DateTime` for CI!
+template nowTmpl(): untyped = initDateTime(15, mMay, 2020, 00, 00, 00, 00, utc())
+
 ggplot(df, aes("x", "y")) +
   geom_line() +
   scale_y_continuous(labels = proc(x: float): string =
                               x.formatFloat(ffDecimal, 1)) +
   scale_x_continuous(labels = proc(x: float): string =
-                              getDateStr(now() - int(x).months)) +
+                              getDateStr(nowTmpl() - int(x).months)) +
   xlab(label = " ") +
   ggsave("media/recipes/rFormatDatesPlot.png")
 #+END_SRC

--- a/recipes/rFormatDatesPlot.nim
+++ b/recipes/rFormatDatesPlot.nim
@@ -5,11 +5,14 @@ let y = x.mapIt(pow(sin(it), 2.0))
 
 let df = seqsToDf(x, y)
 
+# helper template to get a reproducible `DateTime` for CI!
+template nowTmpl(): untyped = initDateTime(15, mMay, 2020, 00, 00, 00, 00, utc())
+
 ggplot(df, aes("x", "y")) +
   geom_line() +
   scale_y_continuous(labels = proc(x: float): string =
                               x.formatFloat(ffDecimal, 1)) +
   scale_x_continuous(labels = proc(x: float): string =
-                              getDateStr(now() - int(x).months)) +
+                              getDateStr(nowTmpl() - int(x).months)) +
   xlab(label = " ") +
   ggsave("media/recipes/rFormatDatesPlot.png")


### PR DESCRIPTION
This fixes an issue with the `rFormatDatesPlot.nim` recipe, which was dependent on the time the recipe is run (since it used `now()`). Instead a template creating a fixed `DateTime` is used now.