### PR TITLE
add `drop_null`, column type conversions

### DIFF
--- a/src/ggplotnim/dataframe/arraymancer_backend.nim
+++ b/src/ggplotnim/dataframe/arraymancer_backend.nim
@@ -2247,7 +2247,8 @@ proc drop_null*(df: DataFrame, cols: varargs[string],
   for col in colsNeedPruning:
     ## TODO: avoid filtering several times somehow?
     ## can read all cols first and then iterate over them? Not necessarily faster
-    result = result.filter(f{Value: isNull(df[col][idx]).toBool == false})
+    let localCol = col # ref: https://github.com/nim-lang/Nim/pull/14447
+    result = result.filter(f{Value: isNull(df[localCol][idx]).toBool == false})
     if convertColumnKind:
       if failIfConversionFails: # ugly workaround
         result[col] = result[col].toNativeColumn(failIfImpossible = true)

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1035,6 +1035,48 @@ t_in_s,  C1_in_V,  C2_in_V,  type
     check dfRes["Ids"].toTensor(float) == dfExp["Ids"].toTensor(float)
     check dfRes["Words"].toTensor(string) == dfExp["Words"].toTensor(string)
 
+  test "Convert (one typed) object column to native":
+    let a = @["A", "B", "C", "D", "E"]
+    let b = @[1, 2, 3, 4, 5]
+    let c = @[1.1, 1.2, 1.3, 1.5]
+    let d = @[true, true, false, true]
+    let aCol = toColumn(%~ a)
+    let bCol = toColumn(%~ b)
+    let cCol = toColumn(%~ c)
+    let dCol = toColumn(%~ d)
+    check aCol.kind == colObject
+    check bCol.kind == colObject
+    check cCol.kind == colObject
+    check dCol.kind == colObject
+    check aCol.toNativeColumn.kind == colString
+    check bCol.toNativeColumn.kind == colInt
+    check cCol.toNativeColumn.kind == colFloat
+    check dCol.toNativeColumn.kind == colBool
+
+  test "Convert multi typed (real object) column to native fails":
+    let a = @["A", "B", "C", "D", "E"]
+    let b = @[1, 2, 3, 4, 5]
+    let ab = concat(%~ a, %~ b)
+    let c = @[1.1, 1.2, 1.3, 1.5]
+    let d = @[true, true, false, true]
+    let cd = concat(%~ c, %~ d)
+    let abCol = toColumn(%~ ab)
+    let cdCol = toColumn(%~ cd)
+    check abCol.kind == colObject
+    check cdCol.kind == colObject
+    try:
+      # This actually works because ints can be converted to string!
+      # that's not really desired behavior, is it?
+      check abCol.toNativeColumn.kind == colString
+      check false
+    except AssertionError:
+      check true
+    try:
+      check cdCol.toNativeColumn.kind == colFloat
+      check false
+    except AssertionError:
+      check true
+
   test "Remove 'null' values from DF":
     let idents = @["A", "B", "C", "D", "E"]
     let ids = @[1, 2, 3, 4, 5]

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -2,6 +2,9 @@ import ggplotnim, unittest, sequtils, math, strutils, streams, sugar
 import algorithm
 import seqmath
 
+when not declared(AssertionDefect):
+  type AssertionDefect = AssertionError
+
 suite "Column":
   test "Constant columns":
     let c = constantColumn(12, 100)

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1116,3 +1116,17 @@ t_in_s,  C1_in_V,  C2_in_V,  type
       check dfRes1[k].toTensor(Value) == dfExp1[k].toTensor(Value)
       check dfRes2[k].toTensor(Value) == dfExp2[k].toTensor(Value)
       check dfRes3[k].toTensor(Value) == dfExp3[k].toTensor(Value)
+
+    # convert manually to correct dtypes
+    check dfRes1["Age"].toNativeColumn.kind == colInt
+    expect(AssertionDefect):
+      check dfRes1["City"].toNativeColumn.kind == colString
+    check dfRes1["City"].toNativeColumn(failIfImpossible = false).kind == colObject
+
+    check dfRes2["City"].toNativeColumn.kind == colString
+    expect(AssertionDefect):
+      check dfRes2["Age"].toNativeColumn.kind == colInt
+    check dfRes2["Age"].toNativeColumn(failIfImpossible = false).kind == colObject
+
+    check dfRes3["Age"].toNativeColumn.kind == colInt
+    check dfRes3["City"].toNativeColumn.kind == colString

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1105,31 +1105,47 @@ t_in_s,  C1_in_V,  C2_in_V,  type
                             "Id" : @[1, 2, 3],
                             "Age" : %~ @[43, 27, 32],
                             "City" : %~ cities[0 ..< ^2]})
-    let dfRes1 = df.drop_null("Age")
-    check dfRes1["Age"].kind == colObject
-    check dfRes1["City"].kind == colObject
-    let dfRes2 = df.drop_null("City")
-    check dfRes2["Age"].kind == colObject
-    check dfRes2["City"].kind == colObject
-    let dfRes3 = df.drop_null()
-    check dfRes3["Age"].kind == colObject
-    check dfRes3["City"].kind == colObject
-    let keys = getKeys(df)
-    for k in keys:
-      check dfRes1[k].toTensor(Value) == dfExp1[k].toTensor(Value)
-      check dfRes2[k].toTensor(Value) == dfExp2[k].toTensor(Value)
-      check dfRes3[k].toTensor(Value) == dfExp3[k].toTensor(Value)
+    block noNativeConversion:
+      let dfRes1 = df.drop_null("Age")
+      check dfRes1["Age"].kind == colObject
+      check dfRes1["City"].kind == colObject
+      let dfRes2 = df.drop_null("City")
+      check dfRes2["Age"].kind == colObject
+      check dfRes2["City"].kind == colObject
+      let dfRes3 = df.drop_null()
+      check dfRes3["Age"].kind == colObject
+      check dfRes3["City"].kind == colObject
+      let keys = getKeys(df)
+      for k in keys:
+        check dfRes1[k].toTensor(Value) == dfExp1[k].toTensor(Value)
+        check dfRes2[k].toTensor(Value) == dfExp2[k].toTensor(Value)
+        check dfRes3[k].toTensor(Value) == dfExp3[k].toTensor(Value)
 
-    # convert manually to correct dtypes
-    check dfRes1["Age"].toNativeColumn.kind == colInt
-    expect(AssertionDefect):
-      check dfRes1["City"].toNativeColumn.kind == colString
-    check dfRes1["City"].toNativeColumn(failIfImpossible = false).kind == colObject
+      # convert manually to correct dtypes
+      check dfRes1["Age"].toNativeColumn.kind == colInt
+      expect(AssertionDefect):
+        check dfRes1["City"].toNativeColumn.kind == colString
+      check dfRes1["City"].toNativeColumn(failIfImpossible = false).kind == colObject
 
-    check dfRes2["City"].toNativeColumn.kind == colString
-    expect(AssertionDefect):
-      check dfRes2["Age"].toNativeColumn.kind == colInt
-    check dfRes2["Age"].toNativeColumn(failIfImpossible = false).kind == colObject
+      check dfRes2["City"].toNativeColumn.kind == colString
+      expect(AssertionDefect):
+        check dfRes2["Age"].toNativeColumn.kind == colInt
+      check dfRes2["Age"].toNativeColumn(failIfImpossible = false).kind == colObject
 
-    check dfRes3["Age"].toNativeColumn.kind == colInt
-    check dfRes3["City"].toNativeColumn.kind == colString
+      check dfRes3["Age"].toNativeColumn.kind == colInt
+      check dfRes3["City"].toNativeColumn.kind == colString
+
+    block nativeConversion:
+      let dfRes1 = df.drop_null("Age", convertColumnKind = true)
+      let dfRes2 = df.drop_null("City", convertColumnKind = true)
+      let dfRes3 = df.drop_null(convertColumnKind = true)
+
+      # convert manually to correct dtypes
+      check dfRes1["Age"].kind == colInt
+      check dfRes1["City"].kind == colObject
+
+      check dfRes2["City"].kind == colString
+      check dfRes2["Age"].kind == colObject
+
+      check dfRes3["Age"].kind == colInt
+      check dfRes3["City"].kind == colString


### PR DESCRIPTION
Addresses #78 by adding `drop_null` and options for convenient column type conversions (latter still missing).

- [x] `drop_null` to remove null rows from df
- [x] allow convenient type conversion of columns from object -> native