### PR TITLE
Misc devel fixes, ggplot object is not generic anymore

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,14 @@
+* v0.3.12
+- =GgPlot= is not a generic anylonger. Originally the idea was to
+  provide support for multiple data types, but nowadays the code base
+  is too intertwined with the =DataFrame= that this doesn't make sense
+  anylonger and in fact produces problems (e.g. "undeclared
+  identifier" when combining implicit generic + template)
+- fix for Nim devel regarding change of named / not named tuples 
+- avoid usage of =random= which is now removed on devel
+* v0.3.11
+Hotfix for Nim devel by @timotheecour. Fixes issues regarding lent
+iterators.
 * v0.3.10
 - fix bug in =add= for data frames if first argument was still =nil= 
 - allow multiple types in =innerJoin=, requirement is that columns to

--- a/recipes.org
+++ b/recipes.org
@@ -871,7 +871,7 @@ for x in 0 ..< 28:
   for y in 0 ..< 28:
     xs.add x.float
     ys.add y.float
-    zs.add random(1.0)
+    zs.add rand(1.0)
 let df = seqsToDf(xs, ys, zs)
 ggplot(df, aes("xs", "ys", fill = "zs")) +
   geom_tile() +

--- a/recipes/rSimpleTile.nim
+++ b/recipes/rSimpleTile.nim
@@ -7,7 +7,7 @@ for x in 0 ..< 28:
   for y in 0 ..< 28:
     xs.add x.float
     ys.add y.float
-    zs.add random(1.0)
+    zs.add rand(1.0)
 let df = seqsToDf(xs, ys, zs)
 ggplot(df, aes("xs", "ys", fill = "zs")) +
   geom_tile() +

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -143,8 +143,8 @@ func fillIds*(aes: Aesthetics, gids: set[uint16]): Aesthetics =
   fillIt(result.yRidges)
   fillIt(result.weight)
 
-proc ggplot*[T](data: T, aes: Aesthetics = aes()): GgPlot[T] =
-  result = GgPlot[T](data: data,
+proc ggplot*(data: DataFrame, aes: Aesthetics = aes()): GgPlot =
+  result = GgPlot(data: data,
                      numXticks: 10,
                      numYticks: 10)
   #result.addAes aes

--- a/src/ggplotnim/collect_and_fill.nim
+++ b/src/ggplotnim/collect_and_fill.nim
@@ -498,82 +498,76 @@ proc collectScales*(p: GgPlot): FilledScales =
   ## Collects all scales required to draw the plot. This means comparing each
   ## possible aesthetic scale of the `GgPlot p` itself with its geoms and
   ## building the final `Scale` for each.
-  # TODO: clean up
-  # if we either put `collect` as template in here or `fillField` as template
-  # (even outside) we get undeclared identifier errors
-  macro fillField(f: static string, arg: typed): untyped =
-    let field = ident(f)
-    let argId = ident(arg.strVal)
-    result = quote do:
-      if `argId`.len > 0 and `argId`[0].ids == {0'u16 .. high(uint16)}:
-        result.`field` = (main: some(`argId`[0]), more: `argId`[1 .. ^1])
-      else:
-        result.`field` = (main: none[Scale](), more: `argId`)
+  template fillField(f: untyped, arg: typed): untyped =
+    if arg.len > 0 and arg[0].ids == {0'u16 .. high(uint16)}:
+      result.f = (main: some(arg[0]), more: arg[1 .. ^1])
+    else:
+      result.f = (main: none[Scale](), more: arg)
   let xs = collect(p, x)
   # NOTE: transformed data handled from this in `callFillScale`!
   let xFilled = callFillScale(p.data, xs, scLinearData)
-  fillField("x", xFilled)
+  fillField(x, xFilled)
   # possibly assign `reversedX` for filledScales
   if xs.anyIt(it.scale.reversed):
     result.reversedX = true
 
   let xsMin = collect(p, xMin)
   let xMinFilled = callFillScale(p.data, xsMin, scLinearData)
-  fillField("xMin", xMinFilled)
+  fillField(xMin, xMinFilled)
 
   let xsMax = collect(p, xMax)
   let xMaxFilled = callFillScale(p.data, xsMax, scLinearData)
-  fillField("xMax", xMaxFilled)
+  fillField(xMax, xMaxFilled)
 
   var ys = collect(p, y)
   # NOTE: transformed data handled from this in `callFillScale`!
   let yFilled = callFillScale(p.data, ys, scLinearData)
-  fillField("y", yFilled)
+  fillField(y, yFilled)
   # possibly assign `reversedX` for filledScales
   if ys.anyIt(it.scale.reversed):
     result.reversedY = true
 
   let ysMin = collect(p, yMin)
   let yMinFilled = callFillScale(p.data, ysMin, scLinearData)
-  fillField("yMin", yMinFilled)
+  fillField(yMin, yMinFilled)
 
   let ysMax = collect(p, yMax)
   let yMaxFilled = callFillScale(p.data, ysMax, scLinearData)
-  fillField("yMax", yMaxFilled)
+  fillField(yMax, yMaxFilled)
 
   let ysRidges = collect(p, yRidges)
   let yRidgesFilled = callFillScale(p.data, ysRidges, scLinearData)
-  fillField("yRidges", yRidgesFilled)
+  fillField(yRidges, yRidgesFilled)
 
   let colors = collect(p, color)
   let colorFilled = callFillScale(p.data, colors, scColor)
-  fillField("color", colorFilled)
+  fillField(color, colorFilled)
   let fills = collect(p, fill)
   let fillFilled = callFillScale(p.data, fills, scFillColor)
-  fillField("fill", fillFilled)
+  fillField(fill, fillFilled)
   let sizes = collect(p, size)
   let sizeFilled = callFillScale(p.data, sizes, scSize)
-  fillField("size", sizeFilled)
+  fillField(size, sizeFilled)
   let shapes = collect(p, shape)
   let shapeFilled = callFillScale(p.data, shapes, scShape)
-  fillField("shape", shapeFilled)
+  fillField(shape, shapeFilled)
 
   let widths = collect(p, width)
   let widthFilled = callFillScale(p.data, widths, scLinearData)
-  fillField("width", widthFilled)
+  fillField(width, widthFilled)
 
   let heights = collect(p, height)
   let heightFilled = callFillScale(p.data, heights, scLinearData)
-  fillField("height", heightFilled)
+  fillField(height, heightFilled)
   # `text` is essentially a "dummy" scale, not required. Only care about
   # the column
   let texts = collect(p, text)
   let textFilled = callFillScale(p.data, texts, scText)
-  fillField("text", textFilled)
+  fillField(text, textFilled)
 
   let weights = collect(p, weight)
   let weightFilled = callFillScale(p.data, weights, scLinearData)
-  fillField("weight", weightFilled)
+  fillField(weight, weightFilled)
 
   # finally add all available facets if any
   if p.facet.isSome:

--- a/src/ggplotnim/dataframe/arraymancer_backend.nim
+++ b/src/ggplotnim/dataframe/arraymancer_backend.nim
@@ -1102,7 +1102,13 @@ proc extractTypes(idents: NimNode): seq[(ReplaceKind, NimNode)] =
       discard
 
 proc parseBool(n: NimNode): bool =
-  result = if n[1].eqIdent(ident"true"): true else: false
+  case n.kind
+  of nnkSym:
+    # should be devel (1.3.5)
+    result = if n.eqIdent(ident"true"): true else: false
+  else:
+    # stable 1.2
+    result = if n[1].eqIdent(ident"true"): true else: false
 
 macro compileFormulaImpl*(rawName, name, body: untyped,
                           bools: untyped,

--- a/src/ggplotnim/dataframe/arraymancer_backend.nim
+++ b/src/ggplotnim/dataframe/arraymancer_backend.nim
@@ -1102,13 +1102,12 @@ proc extractTypes(idents: NimNode): seq[(ReplaceKind, NimNode)] =
       discard
 
 proc parseBool(n: NimNode): bool =
-  case n.kind
-  of nnkSym:
-    # should be devel (1.3.5)
-    result = if n.eqIdent(ident"true"): true else: false
+  when (NimMajor, NimMinor, NimPatch) >= (1, 3, 5):
+    # change to named tuples on Nim devel
+    result = n.eqIdent(ident"true")
   else:
     # stable 1.2
-    result = if n[1].eqIdent(ident"true"): true else: false
+    result = n[1].eqIdent(ident"true")
 
 macro compileFormulaImpl*(rawName, name, body: untyped,
                           bools: untyped,

--- a/src/ggplotnim/ggplot_scales.nim
+++ b/src/ggplotnim/ggplot_scales.nim
@@ -117,7 +117,6 @@ macro genGetOptScale(field: untyped): untyped =
       else:
         # find scale matching `gid`
         for s in filledScales.`field`.more:
-          echo "more ", s
           if geom.gid == 0 or geom.gid in s.ids:
             return some(s)
 

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -276,8 +276,8 @@ type
     font*: Font
     backgroundColor*: Color
 
-  GgPlot*[T] = object
-    data*: T
+  GgPlot* = object
+    data*: DataFrame
     title*: string
     subtitle*: string
     # GgPlot can only contain a single `aes` by itself. Geoms may contain
@@ -560,8 +560,8 @@ macro typeName(x: typed): untyped =
   result = quote do:
     `str`
 
-proc `$`*[T](p: GgPlot[T]): string =
-  result = "(data: " & typeName(p.data)
+proc `$`*(p: GgPlot): string =
+  result = "(data:\n" & $p.data & "\n"
   result.add ", title: " & $p.title
   result.add ", subtitle: " & $p.subtitle
   result.add ", aes: " & $p.aes

--- a/src/ggplotnim/vega_utils.nim
+++ b/src/ggplotnim/vega_utils.nim
@@ -51,7 +51,7 @@ proc collectCols(p: GgPlot): seq[string] =
   ## returns all required columns for the plot
   # iterate all aesthetics and extract columns that are "some"
   # TODO: replace by actual impl
-  result = @[p.aes.x.get.col, p.aes.y.get.col, p.aes.color.get.col]
+  result = @[$p.aes.x.get.col, $p.aes.y.get.col, $p.aes.color.get.col]
 
 proc dataAsJson(p: GgPlot): JsonNode =
   let cols = collectCols(p)
@@ -70,13 +70,13 @@ proc toVegaLite*(p: GgPlot): JsonNode =
   var encoding = newJObject()
   # iterate aes / scales here
   if p.aes.x.isSome:
-    encoding["x"] = %* { "field" : p.aes.x.get.col,
+    encoding["x"] = %* { "field" : $p.aes.x.get.col,
                          "type" : "quantitative" }
   if p.aes.y.isSome:
-    encoding["y"] = %* { "field" : p.aes.y.get.col,
+    encoding["y"] = %* { "field" : $p.aes.y.get.col,
                          "type" : "quantitative" }
   if p.aes.color.isSome:
-    encoding["color"] = %* { "field" : p.aes.color.get.col,
+    encoding["color"] = %* { "field" : $p.aes.color.get.col,
                              "type" : "nominal" }
   result["encoding"] = encoding
   result["data"] = %* {"values" : % p.dataAsJson}


### PR DESCRIPTION
`GgPlot` was generic up to here. However, there was no usage of it being generic and I highly doubt anyone actually made use of that in some bizarre way.

It introduces problems with implicitly generic procs and templates in those leading to "undeclared identifier" errors.

Aside from that a few misc fixes for devel:
- do not use `random`, it's been removed now 
- fix access to tuple to parse literal bool strings