### PR TITLE
make `aes` a macro with untyped & factor support

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,13 @@
+* v0.3.13
+- make =aes= a macro
+  - allows for named / unnamed arguments
+  - raw identifiers will be interpreted as strings, if not symbol is
+    declared with the identifiers name
+  - =factor= can be applied to an argument to force this scale to be
+    discrete. For every scale that is not x/y this wasn't possible
+    (for x/y via =scale_x/y_discrete=)
+- provide better error messages for some mixtures of geoms +
+  continuous scales
 * v0.3.12
 - =GgPlot= is not a generic anylonger. Originally the idea was to
   provide support for multiple data types, but nowadays the code base

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -145,8 +145,8 @@ func fillIds*(aes: Aesthetics, gids: set[uint16]): Aesthetics =
 
 proc ggplot*(data: DataFrame, aes: Aesthetics = aes()): GgPlot =
   result = GgPlot(data: data,
-                     numXticks: 10,
-                     numYticks: 10)
+                  numXticks: 10,
+                  numYticks: 10)
   #result.addAes aes
   result.aes = aes.fillIds({0'u16 .. high(uint16)})
   # TODO: fill others with defaults

--- a/src/ggplotnim/collect_and_fill.nim
+++ b/src/ggplotnim/collect_and_fill.nim
@@ -242,7 +242,8 @@ proc fillContinuousColorScale(scKind: static ScaleKind,
       proc(df: DataFrame): seq[ScaleValue] =
         result = newSeq[ScaleValue](df.len)
         let t = col.evaluate(df).toTensor(float)
-        for idx in 0 ..< df.len:
+        assert t.size == df.len, "Resulting tensor size does not match df len!"
+        for idx in 0 ..< t.size:
           var colorIdx = (255.0 * ((t[idx] - dataScale.low) /
                                    (dataScale.high - dataScale.low))).round.int
           colorIdx = min(255, colorIdx)
@@ -278,7 +279,8 @@ proc fillContinuousSizeScale(col: FormulaNode, vKind: ValueKind,
       proc(df: DataFrame): seq[ScaleValue] =
         let t = col.evaluate(df).toTensor(float)
         result = newSeq[ScaleValue](df.len)
-        for idx in 0 ..< df.len:
+        assert t.size == df.len, "Resulting tensor size does not match df len!"
+        for idx in 0 ..< t.size:
           let size = (t[idx] - minSize) /
                      (maxSize - minSize)
           result[idx] = ScaleValue(kind: scSize,

--- a/src/ggplotnim/collect_and_fill.nim
+++ b/src/ggplotnim/collect_and_fill.nim
@@ -542,12 +542,15 @@ proc collectScales*(p: GgPlot): FilledScales =
   let colors = collect(p, color)
   let colorFilled = callFillScale(p.data, colors, scColor)
   fillField(color, colorFilled)
+
   let fills = collect(p, fill)
   let fillFilled = callFillScale(p.data, fills, scFillColor)
   fillField(fill, fillFilled)
+
   let sizes = collect(p, size)
   let sizeFilled = callFillScale(p.data, sizes, scSize)
   fillField(size, sizeFilled)
+
   let shapes = collect(p, shape)
   let shapeFilled = callFillScale(p.data, shapes, scShape)
   fillField(shape, shapeFilled)

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -588,6 +588,7 @@ proc `$`*(s: Scale): string =
     result.add &", trans.isNil?: {s.trans.isNil}"
     result.add &", secondaryAxis: {s.secondaryAxis}"
   else: discard
+  result.add &", hasDiscreteness: {s.hasDiscreteness}"
   result.add &", dcKind: {s.dcKind}"
   case s.dcKind
   of dcDiscrete:

--- a/src/ggplotnim/postprocess_scales.nim
+++ b/src/ggplotnim/postprocess_scales.nim
@@ -448,6 +448,15 @@ proc filledBinGeom(df: var DataFrame, g: Geom, filledScales: FilledScales): Fill
                              countCol: hist,
                              widthCol: binWidths})
     let key = ("", Value(kind: VNull))
+    # TODO: does it make sense to apply continuous scales to a histogram result?
+    # because: The input DF does not match (element wise) to the resulting DF of
+    # the histogram call. That's a problem, because if one wishes to apply continuous
+    # styling based on some column not part of the histogram call, that column won't
+    # exist for the histogram DF anymore. There isn't really a way to preserve that
+    # information, because it's not well defined how to merge individual rows with
+    # continuous styling to a single bin.
+    # Chances are we end up here, because the "continuous" scale was misclassified
+    doAssert cont.len == 0, "Was " & $cont.mapIt($it.col) & " supposed to be discrete?"
     result.yieldData[toObject(key)] = applyContScaleIfAny(yieldDf, cont, style)
     result.numX = yieldDf.len
     result.xScale = mergeScales(result.xScale, (low: bins.min.float, high: bins.max.float))

--- a/src/ggplotnim/postprocess_scales.nim
+++ b/src/ggplotnim/postprocess_scales.nim
@@ -410,6 +410,7 @@ proc filledBinGeom(df: var DataFrame, g: Geom, filledScales: FilledScales): Fill
   var style: GgStyle
   for setVal in setDiscCols:
     applyStyle(style, df, discretes, setDiscCols.mapIt((it, Value(kind: VNull))))
+
   if mapDiscCols.len > 0:
     df = df.group_by(mapDiscCols)
     # sumHist used to calculate height of stacked histogram. Stored as `float`,


### PR DESCRIPTION
Mainly this PR turns `aes` into a macro.

First of all the functionality of before remains fully unchanged. In addition to that however, the following two things are now possible:

```nim
aes(x, y, color = class) == aes("x", "y", color = "class")
```
which holds, if there are no variables / procs declared with the identifiers given as arguments. Both named and unnamed arguments are of course allowed.

Another new addition is support for `factor`. This forces the associated scale to be interpreted as discrete. For x and y scales this was previously possible using `scale_x/y_discrete`, but no such thing was possible for e.g. a color scale. 
```nim
aes(x, y, color = factor(class))
```
Even if `class` does not actually satisfy the condition for a discrete scale, it will be interpreted as such. Of course this can result in really ugly plots if abused. :)
