### PR TITLE
`hdOutline` means `position = "identity"` for histograms

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,9 @@
+* v0.3.26
+- change =geom_histogram= behavior regarding =hdKind=
+  vs. =position=. If =hdOutline= is used, the default position is
+  =identity=. For normal =hdBars= it is stacking. If both =hdOutline=
+  and =stack= are used, we fall back to =hdBars= with a warning message.
+  
 * v0.3.25
 - fix issue #110; facets now support multiple geoms in one facet plot
 - add classifying using shapes (marker kind & line shape). However,

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1012,3 +1012,35 @@ suite "Annotations":
       # NOTE: `hasDiscreteness` is ``not`` copied over during `collect_and_fill.fillScale`!
       # check cScale.hasDiscreteness
       check cScale.dcKind == dcDiscrete
+
+  test "`geom_histogram` stacks by default, unless `hdOutline` used":
+    let a = @[1,2,3,4,5,6]
+    let df = seqsToDf(a)
+    block:
+      let plt = ggplot(df, aes("a")) + geom_histogram()
+      check plt.geoms.len == 1
+      let g = plt.geoms[0]
+      check g.kind == gkHistogram
+      check g.hdKind == hdBars
+      check g.position == pkStack
+    block:
+      let plt = ggplot(df, aes("a")) + geom_histogram(position = "identity")
+      check plt.geoms.len == 1
+      let g = plt.geoms[0]
+      check g.kind == gkHistogram
+      check g.hdKind == hdBars
+      check g.position == pkIdentity
+    block:
+      let plt = ggplot(df, aes("a")) + geom_histogram(hdKind = hdOutline)
+      check plt.geoms.len == 1
+      let g = plt.geoms[0]
+      check g.kind == gkHistogram
+      check g.hdKind == hdOutline
+      check g.position == pkIdentity
+    block:
+      let plt = ggplot(df, aes("a")) + geom_histogram(hdKind = hdOutline, position = "stack")
+      check plt.geoms.len == 1
+      let g = plt.geoms[0]
+      check g.kind == gkHistogram
+      check g.hdKind == hdBars
+      check g.position == pkStack


### PR DESCRIPTION
This is a small change for the defaults used for histogram. Using histogram outline drawing (`hdKind = hdOutline`) uses identity positioning now. The default of stacking positions with outlines is broken I think.