### PR TITLE
Vega-Lite + TikZ plots in one

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.4.8
+- add =ggvega_tex=, a saving helper that generates the same plot both
+  as a TikZ LaTeX native file (as a =.tex=) as well as a Vega-Lite
+  plot in form of a =.json= file
+- add a LaTeX theme (mainly different font sizes than default).  
 * v0.4.7
 - fix =geom_smooth= internal handling when filling smoothed
   =FilledGeom= objects to raise if input data is considered

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -1329,6 +1329,12 @@ func gridLineColor*(color: Color = white): Theme =
   ## Sets the color of the grid lines.
   result = Theme(gridLineColor: some(color))
 
+proc theme_latex*(): Theme =
+  ## Returns a theme that is designed to produce figures that look nice in a LaTeX document
+  ## without manual adjustment of figure sizes.
+  result = Theme(titleFont: some(font(10.0)),
+                 labelFont: some(font(10.0)))
+
 proc parseTextAlignString(alignTo: string): Option[TextAlignKind] =
   case alignTo.normalize
   of "none": result = none[TextAlignKind]()

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -190,6 +190,13 @@ type
     height*: Option[float]
     asPrettyJson*: bool
 
+  # helper object that refers to 2 plots. A TeX version and a Vega version
+  VegaTeX* = object
+    fname*: string
+    width*: Option[float]
+    height*: Option[float]
+    texOptions*: TeXOptions
+
   # bin position kind stores the different ways bins can be represented
   # Either as left bin edges, center positions or right edges
   BinPositionKind* = enum


### PR DESCRIPTION
Adds a helper that generates the same plot as a `.tex` file (using TikZ) and a Vega-Lite based `.json` file for a native TeX version as well as an interactive version.

Also introduces a new "theme" that changes the font sizes to better defaults for LaTeX.