### PR TITLE
`ColorScale` hotfix

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.5.1
+(as is usual, a hotfix is always coming quickly....)
+- fixes a regression for continuous color scales, where if
+  =scale_color/fill_continuous= was used, we ended up without a color
+  scale in =drawCb=
+- makes sure the indexing of the color scale for raster plots actually
+  uses the number of available colors instead of 256 values  
 * v0.5.0
 - add support for custom (and customized) colormaps
 - add additional =inferno=, =magma=, =plasma= colormap

--- a/src/ggplotnim/ggplot_drawing.nim
+++ b/src/ggplotnim/ggplot_drawing.nim
@@ -340,9 +340,10 @@ proc drawRaster(view: var Viewport, fg: FilledGeom, df: DataFrame) =
     for idx in 0 ..< df.len:
       let (x, y) = (((xT[idx] - minXCol) / wv).round.int,
                     ((yT[idx] - minYCol) / hv).round.int)
-      var colorIdx = (255.0 * ((zT[idx] - zScale.low) /
+      let colorsHigh = cMap.colors.len - 1
+      var colorIdx = (colorsHigh.float * ((zT[idx] - zScale.low) /
                       (zScale.high - zScale.low))).round.int
-      colorIdx = max(0, min(255, colorIdx))
+      colorIdx = max(0, min(colorsHigh, colorIdx))
       let cVal = cMap.colors[colorIdx]
       result[((numY - y - 1) * numX) + x] = cVal
 

--- a/src/ggplotnim/ggplot_styles.nim
+++ b/src/ggplotnim/ggplot_styles.nim
@@ -65,6 +65,21 @@ func defaultStyle(geomKind: GeomKind, statKind: StatKind): Style =
     # raster doesn't have default style atm (what would that imply?)
     discard
 
+proc useOrDefault*(c: ColorScale): ColorScale =
+  ## Either uses the given `ColorScale` (if it defines any colors) or falls back
+  ## to our default
+  ##
+  ## This exists to make sure that a `FilledGeom` receives a `colorScale` field
+  ## with certainty. Otherwise we can end up in the situation that the user makes use
+  ## of a function like `scale_fill_continuous()` (which doesn't set a color scale)
+  ## and we suddenly don't have one.
+  ##
+  ## We could make sure to assign a color scale for every procedure returning a color
+  ## related `Scale`, but given that we don't have an `Option[T]` field, it's more sane
+  ## to handle it like this (in case new procs are added for example).
+  result = if c.colors.len == 0: DefaultColorScale
+           else: c
+
 func mergeUserStyle*(s: GgStyle, fg: FilledGeom): Style =
   ## merges the given `Style` with the desired `userStyle`.
   # Have to differentiate between 3 cases of priority:

--- a/src/ggplotnim/postprocess_scales.nim
+++ b/src/ggplotnim/postprocess_scales.nim
@@ -314,7 +314,7 @@ proc fillOptFields(fg: var FilledGeom, fs: FilledScales, df: var DataFrame) =
     fg.fillCol = getColName(fs)
     if fillScale.get.dcKind == dcContinuous:
       fg.fillDataScale = fs.dataScale
-      fg.colorScale = fs.colorScale
+      fg.colorScale = useOrDefault(fs.colorScale)
   of gkRaster:
     let
       hS = getHeightScale(fs, fg.geom)
@@ -369,7 +369,7 @@ proc fillOptFields(fg: var FilledGeom, fs: FilledScales, df: var DataFrame) =
     let fs = fillScale.get
     fg.fillCol = getColName(fs)
     fg.fillDataScale = fs.dataScale
-    fg.colorScale = fs.colorScale
+    fg.colorScale = useOrDefault(fs.colorScale)
   of gkText:
     fg.text = $getTextScale(fs, fg.geom).col
   of gkHistogram:


### PR DESCRIPTION
After `v0.5.0` we could end up in a situation without a defined `ColorScale`. In addition we were not correctly using the number of available colors for a raster plot.