### PR TITLE
Fix discrete stack vega

### DIFF
--- a/src/ggplotnim/ggplot_vega.nim
+++ b/src/ggplotnim/ggplot_vega.nim
@@ -116,6 +116,13 @@ proc encodeType(encoding: JsonNode, scKind: ScaleKind,
     echo "WARN: losing information in `encodeType`"
     discard
 
+proc assignLabel(encoding: JsonNode, axis: AxisKind, label: string) =
+  case axis
+  of akX:
+    encoding["x"]["axis"] = %* { "title" : label }
+  of akY:
+    encoding["y"]["axis"] = %* { "title" : label }
+
 proc encodeGeomSpecifics(encoding: JsonNode, geom: Geom, df: DataFrame) =
   case geom.kind
   of gkHistogram:
@@ -178,6 +185,8 @@ proc toVegaLite*(p: GgPlot, filledScales: FilledScales, theme: Theme,
   var layers = newJArray()
   let xScale = theme.xMarginRange
   let yScale = theme.yMarginRange
+  let yLab = theme.yLabel.unwrap()
+  let xLab = theme.xLabel.unwrap()
   var df = newDataFrame()
   ## `values` will store the dataframe. However, there will be duplicates in the current
   ## impl depending on multiple geoms with the same data!
@@ -189,6 +198,8 @@ proc toVegaLite*(p: GgPlot, filledScales: FilledScales, theme: Theme,
     let y = $fg.ycol.vegaSanitize
     encoding.encodeType(scLinearData, akX, fg.dcKindX, x, xScale)
     encoding.encodeType(scLinearData, akY, fg.dcKindY, y, yScale)
+    encoding.assignLabel(akX, xLab)
+    encoding.assignLabel(akY, yLab)
     var colors: seq[string]
     var mark: JsonNode
     let scales = collectScales(filledScales, fg.geom)


### PR DESCRIPTION
Test code:

```nim
import ggplotnim
import ggplotnim/ggplot_vega
let mpg = readCsv("mpg.csv")

ggplot(mpg, aes("class", fill = "drv")) +
  geom_bar() +
  ggvega("/t/rMpgStackedBarPlot.html", backend = "browser", removeFile = false)
```

A few notes:
- I'm surprised the stacking is supported automatically. Thought I'd probably have to do something. Note: this means overriding the position (to identity etc.) currently is broken
- it's questionable if this direction of backend suppor for Vega-Lite is super fruitful or if instead we should just aim to have an almost entirely separate backend that avoids the whole internal ggplotnim processing logic and instead just maps the grammar of graphics of ggplot to the vega-lite one.

yields the following (sorry for the ugly link, in contains the vega json):


https://vega.github.io/editor/#/url/vega-lite/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykBaADZ04JACyUAVhDYA7EABoQAEzjQATjRyZ289ADU+QkQAIcgtphNR1cJJjjKTTAJ4myZc5dk0EikDqYgnBoIP4A7jTK9GgAbGIADErwNGRYaGIAHEkq9iiooMRIggxqaADaoFCCSBAQoQBMEHYO6v5QbAyymBAA+gDi-QAKADIA8gAqAHIAkgCyvTNTEwCiAEpTAIIjaACsSji2xPrFfYOjk7MLS6sb22g5yurEoW0AvgpVNXWhHQg4SCgmHanW6Z2G42m80Wy3WWx2qByhzgx1OAwhl2hNzh90RSieL3Q70+IGqtXq6AQUQgNAAXiElB0uj10RcoddYXcEUijidBOC2VcYbd4Q98c9XiAPl9yaEqT4ivJGaCWedIULsVyxSBkaj+az1VjOaK8SoJUSpSSyT90DgaFAANYMHAg5kCw0ckW4nkovnuzGenHc8WEkDEmU2kAQZh-AFA11gg0B4VBtAATgOvLRauTmpNj3NYctEYpUYYL2VbqT7JTWtQAEZ65nfdmMTW896Q5LpaTvqWmi04G1K4mc+3jZ2dVn9WONROEfszaGAGbF3uy9CxwHAkeqttzr0IgDMi91furB9TpoJoVXPetpapyhp9ITe8FRsPaCPmWbev945ftehZ3lafZyjQCpIEqpIqgBl51o2f7nrOn5XgWK5rg+oR2o6zpvvBaF1j6-4XkR+ZdugoElqE0ZMFu8a7oRgZ1g0DTIa2H4sSaGZLreWHgeg0YVrBVaodxk5npxHq1iaSF8VRAkbiAA72EOBFkRJwZTi2M77uRuKLje6BiEpkYMTuomjvpWloPW7E6aR4mybiJ6USApn3oJIBPi+DJWe+MkdseHF6VxLnHr+CkeWZj6QTQioac5wXalJYVBfOdlNtFnlgcpuFOi6TGaRF35HqFzGlcBoa5TRQkxmw-zbklNlVWIFUlSlqBHtlxkxV5ynCS14Vdbs2VpZVXXyX1nkALofCANQuOpqCVD5SDqA6aCgJgLg4CE6BMBt-iYGwbCCDoLqoJg6ilEobBxnQLh2cqFhtOgADEABiADsP2xLEADClogHAsgdMokFkNtIAAB4w8uNBwIIyi-OBSi7ftoSyI1kHFP4SCwzQFI7XQwRo7KbwLc9BQgIjyOo5ucGdZlGN7QdIAAI4MNBgT2Al-nQMUB2gMojVIJBFRJD9CTzUohPEzDgTk0zzJSgtHRvQjSMo6EN5s1j6A4-K+NKELKugOo0FkAd5QgB9sT1mmABCX1ff4H0JAkztpj+Hu-f9QMgPNVNvLNyqyIj0O00djpkOooKM-bKybCnKcE0TJMgPHUSA+dbDvfbbvF+7odAA