### PR TITLE
Better errors fix vega lookup

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.5.7
+- give all ~GeomKind~ fields a name representing the ~geom_*~
+  procedure used to create them (lossy though, not all ~geom_*~
+  procedures have ~GeomKinds~
+- throw exception if no ~y~ scale given when needed and when given if
+  not needed
+- fix issue with Vega backend where we tried to look up internal scale    
 * v0.5.6
 - fixes discrete stacked plots on the Vega-Lite backend
 - avoids showing the internal naming scheme of DF columns in Vega-Lite

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -309,8 +309,15 @@ type
     bbSubset = "subset"
 
   GeomKind* = enum
-    gkPoint, gkBar, gkHistogram, gkFreqPoly, gkTile, gkLine, gkErrorBar, gkText,
-    gkRaster
+    gkPoint     = "geom_point"
+    gkBar       = "geom_bar"
+    gkHistogram = "geom_histogram"
+    gkFreqPoly  = "geom_freqpoly"
+    gkTile      = "geom_tile"
+    gkLine      = "geom_line"
+    gkErrorBar  = "geom_errorbar"
+    gkText      = "geom_text"
+    gkRaster    = "geom_raster"
 
   HistogramDrawingStyle* = enum
     hdBars = "bars" ## draws historams by drawing individual bars right next to

--- a/src/ggplotnim/ggplot_vega.nim
+++ b/src/ggplotnim/ggplot_vega.nim
@@ -11,16 +11,16 @@ const vegaLiteTmpl = """
 """
 
 let mapping = { "title" : "title" }.toTable
-let geom_mapping = { "point" : "point",
-                     "rect" : "rect",
-                     "line" : "line",
-                     "histogram" : "bar",
-                     "bar" : "bar",
-                     "freqpoly" : "line",
-                     "tile" : "rect",
-                     "text" : "text",
-                     "raster" : "rect", # or image?,
-                     "errorbar" : "errorbar" # non trivial because they are split in vega
+let geom_mapping = { "geom_point" : "point",
+                     "geom_rect" : "rect",
+                     "geom_line" : "line",
+                     "geom_histogram" : "bar",
+                     "geom_bar" : "bar",
+                     "geom_freqpoly" : "line",
+                     "geom_tile" : "rect",
+                     "geom_text" : "text",
+                     "geom_raster" : "rect", # or image?,
+                     "geom_errorbar" : "errorbar" # non trivial because they are split in vega
                    }.toTable
 
 template toVegaField(f: string): string =
@@ -35,7 +35,7 @@ iterator enumerateData(geom: FilledGeom): (Value, GgStyle, seq[GgStyle], DataFra
     yield (label, tup[0], tup[1], tup[2])
 
 proc mapGeomKind(gk: GeomKind): string =
-  result = geom_mapping[($gk).replace("gk", "").toLowerAscii]
+  result = geom_mapping[$gk]
 
 proc toJson(v: Value): JsonNode =
   case v.kind

--- a/src/ggplotnim/ggplot_vega.nim
+++ b/src/ggplotnim/ggplot_vega.nim
@@ -210,9 +210,9 @@ proc toVegaLite*(p: GgPlot, filledScales: FilledScales, theme: Theme,
       mark = genMark(fg, style)
       encoding.encodeGeomSpecifics(fg.geom, subDf)
       var locDf = subDf
-      for sc in scales:
+      for sc in scales: # NOTE: this _also_ returns scales that were used internally like `weight`!
         let scCol = sc.getValidColName()
-        if scCol notin locDf:
+        if scCol notin locDf and scCol in lab:
           locDf[scCol] = lab[scCol].toStr
         if styles.len == 1: # discrete
           for key, val in lab:

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -385,6 +385,26 @@ suite "GgPlot":
                       epsilon = 1e-6)
     plt.ggdraw("exp2.pdf")
 
+  test "Plot requiring `y` scale throws if none given":
+    let mpg = readCsv("data/mpg.csv")
+    try:
+      ggplot(mpg, aes("year")) +
+        geom_point() +
+        ggsave("never_produced.png")
+      check false
+    except AestheticError:
+      check true
+
+  test "Plot not needing `y` scale throws if given":
+    let mpg = readCsv("data/mpg.csv")
+    try:
+      ggplot(mpg, aes(x = "class", y = "cyl")) +
+        geom_bar() +
+        ggsave("never_produced.png")
+      check false
+    except AestheticError:
+      check true
+
 suite "Theme":
   test "Canvas background color":
     let mpg = readCsv("data/mpg.csv")


### PR DESCRIPTION
Here's a fix for #158. We can simply ignore looking up any scale that isn't known in the "labels", as those will be internal and therefore not needed.

Also adds exceptions for two use cases where y scales are given but not needed and required but not given.