### PR TITLE
Support `weights` in `geom_bar`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.5.8
+- support ~weights~ in ~geom_bar~, previously it was ignored
 * v0.5.7
 - give all ~GeomKind~ fields a name representing the ~geom_*~
   procedure used to create them (lossy though, not all ~geom_*~


### PR DESCRIPTION
Note: using `weights` in `geom_bar` or `geom_histogram` does not adjust the name of the y label. It is advised to change the `"count"` to something resembling the fact that it is a weighted count. But this is left up to the user.