### PR TITLE
Allow import of SDL2 backend and text placement improvements

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.5.14
+- make SDL2 backend a full submodule that can be imported using
+  ~import ggplotnim/ggplot_sdl2~
+- ~-d:experimentalSDL2~ is still supported and imports/exports the
+  module for you  
 * v0.5.13
 - do not crash SDL2 viewer when resizing the window too much
 - implement panning (left mouse button), mouse wheel zooming. Zooming

--- a/changelog.org
+++ b/changelog.org
@@ -2,7 +2,12 @@
 - make SDL2 backend a full submodule that can be imported using
   ~import ggplotnim/ggplot_sdl2~
 - ~-d:experimentalSDL2~ is still supported and imports/exports the
-  module for you  
+  module for you
+- allow to also save a plot at the same time as showing it, by handing
+  a filename argument to ~ggshow~  
+- update ~ginger~ dependency to ~v0.5.0~. This fixes our previously
+  still not quite correct placement of text which relied on string
+  width/height information. Now it is also correct on the TikZ backend
 * v0.5.13
 - do not crash SDL2 viewer when resizing the window too much
 - implement panning (left mouse button), mouse wheel zooming. Zooming

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -3102,8 +3102,8 @@ proc ggcreate*[T: SomeNumber](p: GgPlot, width: T = 640.0, height: T = 480.0): P
   result.filledScales = filledScales
   result.view = img
 
-proc toTeXOptions(useTeX, onlyTikZ, standalone: bool, texTemplate: string,
-                  caption, label, placement: string): TeXOptions =
+proc toTeXOptions*(useTeX, onlyTikZ, standalone: bool, texTemplate: string,
+                   caption, label, placement: string): TeXOptions =
   result = TeXOptions(
       texTemplate: if texTemplate.len > 0: some(texTemplate)
                    else: none(string),

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -3293,8 +3293,31 @@ proc ggsave*(fname: string, width = 640.0, height = 480.0,
   ## 3. `standalone`: only chosen if above two are `false` / empty
   ##
   ## Further, if a `texTemplate` is given that template is used to embed the `TikZ` code.
-  ## The template ``must`` contain a single `$#` for the location at which the `TikZ` code
-  ## is to be embeded.
+  ## The template ``must`` contain three `$#` for the location at which the `TikZ` code
+  ## is to be embeded. An example (using `latexdsl`) of where these must be:
+  ##
+  ## ```latex
+  ##    \documentclass[a4paper]{article}
+  ##    \usepackage[utf8]{inputenc}
+  ##    \usepackage[margin="2.5cm"]{geometry}
+  ##    \usepackage{unicode-math} # for unicode support in math environments
+  ##    \usepackage{amsmath}
+  ##    \usepackage{siunitx}
+  ##    \usepackage{tikz}
+  ##    "$#"
+  ##    document:
+  ##      "$#"
+  ##      center:
+  ##        tikzpicture:
+  ##          "$#"
+  ##
+  ## ```
+  ##
+  ## The first is an additional header (currently unused). The second is a header for the document body.
+  ## This is where for example the page color is set based on the plot background. Finally the third is
+  ## the actual TikZ code inserted. Generally it is a good idea to start with the above template and
+  ## adjust the type of article, packages to use etc. as needed.
+  ##
   ##
   ## Finally, if a `caption` and / or `label` are given, the output will wrap the `tikzpicture`
   ## in a figure environment, with placement options `placement`.

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -3024,7 +3024,7 @@ proc ggcreate*[T: SomeNumber](p: GgPlot, width: T = 640.0, height: T = 480.0): P
                          backend = p.backend)
 
   # set color of canvas background
-  img.background(style = some(getCanvasBackground(theme)))
+  img.background(style = some(getCanvasBackground(theme)), name = "canvasBackground")
 
   img.createLayout(filledScales, theme)
   # get viewport of plot

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -3425,4 +3425,5 @@ proc `+`*(p: GgPlot, jsDraw: JsonDummyDraw) =
   writeFile(jsDraw.fname, json.`$`(% plt.view))
 
 when defined(experimentalSDL2):
-  include ggplotnim/sdl2_backend
+  import ggplotnim/ggplot_sdl2
+  export ggplot_sdl2

--- a/src/ggplotnim/ggplot_drawing.nim
+++ b/src/ggplotnim/ggplot_drawing.nim
@@ -193,7 +193,7 @@ func getDiscretePoint(fg: FilledGeom, axKind: AxisKind): Coord1D =
   # discrete points are...
   result = c1(0.5, ukRelative)
 
-func getDiscreteLine(view: Viewport, axKind: AxisKind): Coord1D =
+proc getDiscreteLine(view: Viewport, axKind: AxisKind): Coord1D =
   # discrete points are...
   case axKind
   of akX:

--- a/src/ggplotnim/ggplot_sdl2.nim
+++ b/src/ggplotnim/ggplot_sdl2.nim
@@ -1,9 +1,10 @@
 import std / [math, os]
-
 import sdl2 except Color, Point
 
-import ginger
-import cairo
+import pkg / [ggplotnim, ginger, cairo]
+
+# Zoom mentioned these two libs as options for file dialogs
+# > I forgot which one worked better, https://github.com/Patitotective/tinydialogs or https://github.com/Tormund/os_files last time I checked
 
 proc draw*(renderer: RendererPtr, sdlSurface: SurfacePtr, view: Viewport, filename: string, texOptions: TeXOptions = TeXOptions()) =
   var img = initBImage(CairoBackend,

--- a/src/ggplotnim/ggplot_sdl2.nim
+++ b/src/ggplotnim/ggplot_sdl2.nim
@@ -284,12 +284,39 @@ type
   SdlDraw* = object
     width: int
     height: int
+    draw: Draw
 
 proc `+`*(p: GgPlot, sdlDraw: SdlDraw) =
+  # 1. create the output file (if filename given)
+  if sdlDraw.draw.fname.len > 0:
+    p + sdlDraw.draw
+  # 2. render the plot
   var plt = p
   plt.backend = bkCairo
   var ctx = initContext(plt)
   ctx.render(sdlDraw.width, sdlDraw.height)
 
+proc ggshow*(fname: string,
+             width = 640.0, height = 480.0,
+             useTeX = false,
+             onlyTikZ = false,
+             standalone = false,
+             texTemplate = "",
+             caption = "",
+             label = "",
+             placement = "htbp",
+             backend = bkNone): SdlDraw =
+  ## Overload of `ggshow` which also produces a regular plot.
+  let texOptions = toTeXOptions(useTeX, onlyTikZ, standalone, texTemplate,
+                                caption, label, placement)
+  let draw = Draw(fname: fname,
+                  width: some(width),
+                  height: some(height),
+                  texOptions: texOptions,
+                  backend: backend)
+  result = SdlDraw(width: width.round.int, height: height.round.int, draw: draw)
+
 proc ggshow*(width = 640, height = 480): SdlDraw =
+  ## Creates an SDL2 window in which the plot will be shown. Basic mouse interaction is possible
+  ## to pan and zoom (mouse wheel and right click -> zoom to rectangle).
   result = SdlDraw(width: width, height: height)

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -475,6 +475,8 @@ type
     theme*: Theme
     backend*: BackendKind ## the backend to use. Determined automatically from filename and
                           ## possible options given to `ggsave`
+    fType*: FileTypeKind ## The file type we render to. This is needed for accurate information
+                         ## about the height / width of text.
 
   StyleLabel* = object
     style*: GgStyle


### PR DESCRIPTION
The SDL2 backend can now be imported (instead of only available via `-d:experimentalSDL2`) by `import ggplotnim/ggplot_sdl2`.

This update, thanks to upgrading to `ginger v0.5.0` fixes many small and large issues with coordinates dependent on text width/height information. Majorly improves the TikZ backend output.

```
* v0.5.14
- make SDL2 backend a full submodule that can be imported using
  ~import ggplotnim/ggplot_sdl2~
- ~-d:experimentalSDL2~ is still supported and imports/exports the
  module for you
- allow to also save a plot at the same time as showing it, by handing
  a filename argument to ~ggshow~  
- update ~ginger~ dependency to ~v0.5.0~. This fixes our previously
  still not quite correct placement of text which relied on string
  width/height information. Now it is also correct on the TikZ backend
```