### PR TITLE
Avoid duplicates when drawing with constant `aes`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.6.2
+- handle geom calls with constant values better. Previously we
+  sometimes ended up drawing the same e.g. text multiple times, once
+  for each input DF row. We now deduplicate for cases where ~x~ and
+  ~y~ are constant.
 * v0.6.1
 - do not change the top margin of a plot based on a legend being added
   anymore. That's kind of jarring.

--- a/ggplotnim.nimble
+++ b/ggplotnim.nimble
@@ -10,7 +10,7 @@ srcDir        = "src"
 
 requires "nim >= 1.0.0"
 requires "https://github.com/Vindaar/seqmath >= 0.1.16"
-requires "ginger == 0.5.1"
+requires "ginger == 0.5.2"
 requires "datamancer >= 0.3.2"
 requires "arraymancer >= 0.7.22"
 requires "shell >= 0.4.3"

--- a/src/ggplotnim/collect_and_fill.nim
+++ b/src/ggplotnim/collect_and_fill.nim
@@ -244,6 +244,15 @@ proc fillDiscreteLinearTransScale(
     result.trans = trans.get
     result.invTrans = invTrans.get
 
+proc fillDiscreteTextScale(
+  scKind: static ScaleKind,
+  col: FormulaNode,
+  vKind: ValueKind, labelSeq: seq[Value]
+     ): Scale =
+  result = Scale(scKind: scKind, vKind: vKind, col: col, dcKind: dcDiscrete)
+  result.labelSeq = labelSeq
+  result.valueMap = initOrderedTable[Value, ScaleValue]()
+
 proc fillContinuousLinearScale(col: FormulaNode, axKind: AxisKind, vKind: ValueKind,
                                dataScale: ginger.Scale): Scale =
   result = Scale(scKind: scLinearData, vKind: vKind, col: col, dcKind: dcContinuous,
@@ -429,8 +438,8 @@ proc fillScaleImpl(
                                             trans, invTrans)
     of scShape:
       result = fillDiscreteShapeScale(vKind, col, labelSeq, valueMapOpt)
-    of scText: result = Scale(scKind: scText,
-                              col: col) # nothing required but the column
+    of scText:
+      result = fillDiscreteTextScale(scText, col, vKind, labelSeq) # nothing required but the column
   else:
     let dataScale = dataScaleOpt.unwrap()
     case scKind


### PR DESCRIPTION
Fixes duplication of constant geoms.

For example a geom like:

```
geom_text(aes = aes(x = 1.0, y = 2.0, text = "foo"))
```

would previously draw the text once for every row in the input DF.



```
* v0.6.2
- handle geom calls with constant values better. Previously we
  sometimes ended up drawing the same e.g. text multiple times, once
  for each input DF row. We now deduplicate for cases where ~x~ and
  ~y~ are constant.
```