### PR TITLE
Nix not very helpful geom_ name-space prefix in `GeomKind` enum strings.

### DIFF
--- a/recipes.org
+++ b/recipes.org
@@ -2447,7 +2447,7 @@ This gives us two =seq[float]=, but we need a =DataFrame=. So we
 combine the two:
 #+BEGIN_SRC nim :tangle recipes/rNewtonAcceleration.nim
 var df = toDf({ "r / m" : radii,
-                    "g(r) / m s¯²" : a})
+                "g(r) / m s¯²" : a})
 #+END_SRC
 which gives us a data frame with two columns. The names are, as one can
 guess, the given strings. (Note that in practice one might not want to
@@ -2481,7 +2481,7 @@ At this point we might ask "Do we recover the known 9.81 m/s^2 at the
 surface?". Let's see. There's many different ways we could go on about
 this. We'll use summarize:
 #+BEGIN_SRC nim :tangle recipes/rNewtonAcceleration.nim
-let maxG = df.summarize(f{float: "g_max" << max(c"g(r) / m s¯²")})
+let maxG = df.summarize(f{float: "g_max" << max(col("g(r) / m s¯²"))})
 #+END_SRC
 
 An alternative way would be to access the data column directly, like

--- a/recipes/rNewtonAcceleration.nim
+++ b/recipes/rNewtonAcceleration.nim
@@ -19,7 +19,7 @@ let radii = linspace(0.0, 35_000_000, 1000) # up to geostationary orbit
 let a = radii.mapIt(newtonAcceleration(it))
 
 var df = toDf({ "r / m" : radii,
-                    "g(r) / m s¯²" : a})
+                "g(r) / m s¯²" : a})
 
 df = df.transmute(f{"r / km" ~ c"r / m" / 1000.0}, f{"g(r) / m s¯²"})
 
@@ -28,7 +28,7 @@ ggplot(df, aes("r / km", "g(r) / m s¯²")) +
   ggtitle("Gravitational acceleration of Earth depending on radial distance") +
   ggsave("media/recipes/rNewtonAcceleration.png")
 
-let maxG = df.summarize(f{float: "g_max" << max(c"g(r) / m s¯²")})
+let maxG = df.summarize(f{float: "g_max" << max(col("g(r) / m s¯²"))})
 
 let maxG_alt = df["g(r) / m s¯²"].toTensor(float).max
 

--- a/src/ggplotnim/ggplot_types.nim
+++ b/src/ggplotnim/ggplot_types.nim
@@ -324,15 +324,15 @@ type
     bbSubset = "subset"
 
   GeomKind* = enum
-    gkPoint     = "geom_point"
-    gkBar       = "geom_bar"
-    gkHistogram = "geom_histogram"
-    gkFreqPoly  = "geom_freqpoly"
-    gkTile      = "geom_tile"
-    gkLine      = "geom_line"
-    gkErrorBar  = "geom_errorbar"
-    gkText      = "geom_text"
-    gkRaster    = "geom_raster"
+    gkPoint     = "point"
+    gkBar       = "bar"
+    gkHistogram = "histogram"
+    gkFreqPoly  = "freqpoly"
+    gkTile      = "tile"
+    gkLine      = "line"
+    gkErrorBar  = "errorbar"
+    gkText      = "text"
+    gkRaster    = "raster"
 
   HistogramDrawingStyle* = enum
     hdBars = "bars" ## draws historams by drawing individual bars right next to

--- a/src/ggplotnim/ggplot_vega.nim
+++ b/src/ggplotnim/ggplot_vega.nim
@@ -11,16 +11,16 @@ const vegaLiteTmpl = """
 """
 
 let mapping = { "title" : "title" }.toTable
-let geom_mapping = { "geom_point" : "point",
-                     "geom_rect" : "rect",
-                     "geom_line" : "line",
-                     "geom_histogram" : "bar",
-                     "geom_bar" : "bar",
-                     "geom_freqpoly" : "line",
-                     "geom_tile" : "rect",
-                     "geom_text" : "text",
-                     "geom_raster" : "rect", # or image?,
-                     "geom_errorbar" : "errorbar" # non trivial because they are split in vega
+let geom_mapping = { "point" : "point",
+                     "rect" : "rect",
+                     "line" : "line",
+                     "histogram" : "bar",
+                     "bar" : "bar",
+                     "freqpoly" : "line",
+                     "tile" : "rect",
+                     "text" : "text",
+                     "raster" : "rect", # or image?,
+                     "errorbar" : "errorbar" # non trivial because they are split in vega
                    }.toTable
 
 template toVegaField(f: string): string =


### PR DESCRIPTION
Other `enum` s here do not namespace prefix.  For `$` purposes this can be more clear, but it creates work for users entering strings for `parseEnum`.