### PR TITLE
make sure discreteness is set for log2 / log10 scales

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - 'src/**'
       - 'ggplotnim.nimble'
       - '.github/workflows/ci.yml'
+    branches:
+      - 'master'
   pull_request:
     paths:
       - 'tests/**'

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.7.2
+- fix ~scale_x/y_log2/10~ when using it on scales that 'appear' to be
+  discrete based on their data. It was missing the boolean to indicate
+  that a fixed discreteness is set
 * v0.7.1
 - update datamancer dependency for the fix of ~arrange~ in
   https://github.com/SciNim/Datamancer/pull/68 for issue

--- a/src/ggplotnim.nim
+++ b/src/ggplotnim.nim
@@ -917,6 +917,7 @@ proc scale_x_log10*[T: int | seq[SomeNumber]](breaks: T = newSeq[float]()): Scal
                  scKind: scTransformedData,
                  axKind: akX,
                  dcKind: dcContinuous,
+                 hasDiscreteness: true,
                  trans: trans,
                  invTrans: invTrans)
   result.assignBreaks(breaks)
@@ -939,6 +940,7 @@ proc scale_y_log10*[T: int | seq[SomeNumber]](breaks: T = newSeq[float]()): Scal
                  scKind: scTransformedData,
                  axKind: akY,
                  dcKind: dcContinuous,
+                 hasDiscreteness: true,
                  trans: trans,
                  invTrans: invTrans)
   result.assignBreaks(breaks)
@@ -961,6 +963,7 @@ proc scale_x_log2*[T: int | seq[SomeNumber]](breaks: T = newSeq[float]()): Scale
                  scKind: scTransformedData,
                  axKind: akX,
                  dcKind: dcContinuous,
+                 hasDiscreteness: true,
                  trans: trans,
                  invTrans: invTrans)
   result.assignBreaks(breaks)
@@ -983,6 +986,7 @@ proc scale_y_log2*[T: int | seq[SomeNumber]](breaks: T = newSeq[float]()): Scale
                  scKind: scTransformedData,
                  axKind: akY,
                  dcKind: dcContinuous,
+                 hasDiscreteness: true,
                  trans: trans,
                  invTrans: invTrans)
   result.assignBreaks(breaks)


### PR DESCRIPTION
Without it if the data is interpreted to be discrete and not continuous, we run into a invalid field of variant object issue.